### PR TITLE
fix: remove the `_decode` function

### DIFF
--- a/src/salte-auth.js
+++ b/src/salte-auth.js
@@ -949,59 +949,8 @@ export default class AuthenticationContext {
   }
 
   _base64DecodeStringUrlSafe(base64IdToken) {
-    // html5 should support atob function for decoding
     base64IdToken = base64IdToken.replace(/-/g, '+').replace(/_/g, '/');
-    if (window.atob) {
-      return decodeURIComponent(escape(window.atob(base64IdToken)));
-    }
-    return decodeURIComponent(escape(this._decode(base64IdToken)));
-  }
-
-  // Take https://cdnjs.cloudflare.com/ajax/libs/Base64/0.3.0/base64.js and https://en.wikipedia.org/wiki/Base64 as reference.
-  _decode(base64IdToken) {
-    const codes = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
-    base64IdToken = String(base64IdToken).replace(/[=]+$/, '');
-
-    const length = base64IdToken.length;
-    if (length % 4 === 1) {
-      throw new Error('The token to be decoded is not correctly encoded.');
-    }
-
-    let h1, h2, h3, h4, bits, c1, c2, c3;
-    let decoded = '';
-    for (let i = 0; i < length; i += 4) {
-      // Every 4 base64 encoded character will be converted to 3 byte string, which is 24 bits
-      // then 6 bits per base64 encoded character
-      h1 = codes.indexOf(base64IdToken.charAt(i));
-      h2 = codes.indexOf(base64IdToken.charAt(i + 1));
-      h3 = codes.indexOf(base64IdToken.charAt(i + 2));
-      h4 = codes.indexOf(base64IdToken.charAt(i + 3));
-
-      // For padding, if last two are '='
-      if (i + 2 === length - 1) {
-        bits = h1 << 18 | h2 << 12 | h3 << 6;
-        c1 = bits >> 16 & 255;
-        c2 = bits >> 8 & 255;
-        decoded += String.fromCharCode(c1, c2);
-        break;
-      } else if (i + 1 === length - 1) { // if last one is '='
-        bits = h1 << 18 | h2 << 12;
-        c1 = bits >> 16 & 255;
-        decoded += String.fromCharCode(c1);
-        break;
-      }
-
-      bits = h1 << 18 | h2 << 12 | h3 << 6 | h4;
-
-      // then convert to 3 byte chars
-      c1 = bits >> 16 & 255;
-      c2 = bits >> 8 & 255;
-      c3 = bits & 255;
-
-      decoded += String.fromCharCode(c1, c2, c3);
-    }
-
-    return decoded;
+    return decodeURIComponent(escape(window.atob(base64IdToken)));
   }
 
     // Auth.node js crack function

--- a/tests/salte-auth/salte-auth.spec.js
+++ b/tests/salte-auth/salte-auth.spec.js
@@ -745,28 +745,6 @@ describe('salte-auth', () => {
     });
   });
 
-  describe('function: _decode', () => {
-    it('test decode with no padding', () => {
-      expect(auth._decode('ZGVjb2RlIHRlc3Rz')).to.equal('decode tests');
-    });
-
-    it('test decode with one = padding', () => {
-      expect(auth._decode('ZWNvZGUgdGVzdHM=')).to.equal('ecode tests');
-    });
-
-    it('test decode with two == padding', () => {
-      expect(auth._decode('Y29kZSB0ZXN0cw==')).to.equal('code tests');
-    });
-
-    it('test decode throw error', () => {
-      try {
-        auth._decode('YW55I');
-      } catch (e) {
-        expect(e.message).to.equal('The token to be decoded is not correctly encoded.');
-      }
-    });
-  });
-
   describe('function: _getHostFromUri', () => {
     it('test host extraction', () => {
       expect(auth._getHostFromUri('https://a.com/b/c')).to.equal('a.com');


### PR DESCRIPTION
This drops support for the following browsers:
- IE 9 and lower

closes #17 
