### PR TITLE
fix: rewriting the location causes the route to refresh

### DIFF
--- a/src/salte-auth.js
+++ b/src/salte-auth.js
@@ -259,7 +259,11 @@ export default class AuthenticationContext {
       try {
         if (popupWindow.location.href.indexOf(registeredRedirectUri) !== -1) {
           if (this.isAngular) {
-            this.callback && this.callback();
+            if (this.callback) {
+              this.callback();
+            } else {
+              window.location.hash = popupWindow.location.hash;
+            }
           } else {
             this.handleWindowCallback(popupWindow.location.hash, popupWindow.location.search);
           }

--- a/src/salte-auth.js
+++ b/src/salte-auth.js
@@ -259,7 +259,6 @@ export default class AuthenticationContext {
       try {
         if (popupWindow.location.href.indexOf(registeredRedirectUri) !== -1) {
           if (this.isAngular) {
-            window.location.hash = popupWindow.location.hash;
             this.callback && this.callback();
           } else {
             this.handleWindowCallback(popupWindow.location.hash, popupWindow.location.search);


### PR DESCRIPTION
@davewoodward I'm not entirely sure what the implications of this change are.

Not entirely sure if Angular was using this for the case when the routes were prefixed with `#`.