### PR TITLE
fix: login with redirect no longer races the initial route change

### DIFF
--- a/src/salte-auth.js
+++ b/src/salte-auth.js
@@ -289,15 +289,27 @@ class SalteAuth {
 
   /**
    * Authenticates using the redirect-based OAuth flow.
+   * @return {Promise} a promise that resolves on
    */
   loginWithRedirect() {
     if (!this.$config.redirectLoginCallback) {
       throw new ReferenceError('A redirectLoginCallback is required to invoke "loginWithRedirect"!');
     }
 
+    if (this.$promises.login) {
+      return this.$promises.login;
+    }
+
+    // NOTE: This prevents the other login types from racing "loginWithRedirect".
+    // Without this someone could potentially call login somewhere else before
+    // the app has a change to redirect. Which could result in an invalid state.
+    this.$promises.login = new Promise((resolve) => setTimeout(resolve));
+
     this.profile.$clear();
     this.profile.$redirectUrl = this.profile.$redirectUrl || location.href;
     location.href = this.$loginUrl;
+
+    return this.$promises.login;
   }
 
   /**

--- a/tests/salte-auth/salte-auth.spec.js
+++ b/tests/salte-auth/salte-auth.spec.js
@@ -687,6 +687,10 @@ describe('salte-auth', () => {
   });
 
   describe('function(loginWithRedirect)', () => {
+    beforeEach(() => {
+      window.setTimeout.restore();
+    });
+
     it('should resolve when we have logged in', () => {
       sandbox.stub(auth.profile, '$clear');
       sandbox.stub(auth, '$loginUrl').get(() => location.href);
@@ -697,6 +701,22 @@ describe('salte-auth', () => {
       expect(auth.profile.$clear.callCount).to.equal(1);
       expect(auth.profile.$redirectUrl).to.equal(location.href);
       expect(auth.$promises.logout).to.be.undefined;
+    });
+
+    it('should prevent duplicate promises', () => {
+      sandbox.stub(auth.profile, '$clear');
+      sandbox.stub(auth, '$loginUrl').get(() => location.href);
+      auth.$config.redirectLoginCallback = sandbox.stub();
+
+      const promise = auth.loginWithRedirect();
+      const duplicatePromise = auth.loginWithRedirect();
+
+      expect(promise).to.equal(duplicatePromise);
+
+      expect(auth.profile.$clear.callCount).to.equal(1);
+      expect(auth.profile.$redirectUrl).to.equal(location.href);
+
+      return promise;
     });
 
     it('should require a "redirectLoginCallback" to be provided', () => {


### PR DESCRIPTION
This resolves any race conditions that could occur with `loginWithRedirect` 
in which multiple login requests were initiated within the same event frame.

closes #135