### PR TITLE
fix: loginWithRedirect should never resolve

### DIFF
--- a/src/salte-auth.js
+++ b/src/salte-auth.js
@@ -303,7 +303,7 @@ class SalteAuth {
     // NOTE: This prevents the other login types from racing "loginWithRedirect".
     // Without this someone could potentially call login somewhere else before
     // the app has a change to redirect. Which could result in an invalid state.
-    this.$promises.login = new Promise((resolve) => setTimeout(resolve));
+    this.$promises.login = new Promise(() => {});
 
     this.profile.$clear();
     this.profile.$redirectUrl = this.profile.$redirectUrl || location.href;

--- a/tests/salte-auth/salte-auth.spec.js
+++ b/tests/salte-auth/salte-auth.spec.js
@@ -715,8 +715,6 @@ describe('salte-auth', () => {
 
       expect(auth.profile.$clear.callCount).to.equal(1);
       expect(auth.profile.$redirectUrl).to.equal(location.href);
-
-      return promise;
     });
 
     it('should require a "redirectLoginCallback" to be provided', () => {


### PR DESCRIPTION
**Here's the breakdown of whats going on:**

* `salte-auth` Initializes
* Developer initiates `loginWithRedirect`
* `salte-auth` calls `retrieveAccessToken`
* Promise returned by `loginWithRedirect` resolves
* The browser finally navigates to the `/authorize` page

**What does this PR change?**

`loginWithRedirect` will never resolve, this is to ensure that we navigate 
away from the page before we attempt to retrieve an `accessToken`.

Related to #140 