### PR TITLE
fix(interceptors): fetch should support all of the natively supported classes

### DIFF
--- a/src/salte-auth.js
+++ b/src/salte-auth.js
@@ -106,11 +106,10 @@ class SalteAuth {
         }
       });
 
-      this.$utilities.addFetchInterceptor((input, options) => {
-        if (this.$utilities.checkForMatchingUrl(input, this.$config.endpoints)) {
+      this.$utilities.addFetchInterceptor((request) => {
+        if (this.$utilities.checkForMatchingUrl(request.url, this.$config.endpoints)) {
           return this.retrieveAccessToken().then((accessToken) => {
-            options.headers = options.headers || {};
-            options.headers.Authorization = `Bearer ${accessToken}`;
+            request.headers.set('Authorization', `Bearer ${accessToken}`);
           });
         }
       });

--- a/src/salte-auth.utilities.js
+++ b/src/salte-auth.utilities.js
@@ -43,11 +43,13 @@ class SalteAuthUtilities {
 
     if (window.fetch) {
       (function(fetch) {
-        window.fetch = function(input, options = {}) {
+        window.fetch = function(input, options) {
+          const request = input instanceof Request ? input : new Request(input, options);
+
           const promises = [];
           for (let i = 0; i < self.$interceptors.fetch.length; i++) {
             const interceptor = self.$interceptors.fetch[i];
-            promises.push(interceptor(input, options));
+            promises.push(interceptor(request));
           }
           return Promise.all(promises).then(() => {
             return fetch.call(this, input, options);

--- a/tests/salte-auth/salte-auth.spec.js
+++ b/tests/salte-auth/salte-auth.spec.js
@@ -214,9 +214,9 @@ describe('salte-auth', () => {
         .stub(auth, 'retrieveAccessToken')
         .returns(Promise.resolve('55555-55555'));
 
-      auth.$utilities.addFetchInterceptor((input, options) => {
+      auth.$utilities.addFetchInterceptor((request) => {
         return Promise.resolve().then(() => {
-          expect(options.headers.Authorization).to.equal('Bearer 55555-55555');
+          expect(request.headers.get('Authorization')).to.equal('Bearer 55555-55555');
         });
       });
 
@@ -224,9 +224,9 @@ describe('salte-auth', () => {
     });
 
     it('should not request a new access token if we do not need to be authenticated', () => {
-      auth.$utilities.addFetchInterceptor((input, options) => {
+      auth.$utilities.addFetchInterceptor((request) => {
         return Promise.resolve().then(() => {
-          expect(options.headers).to.be.undefined;
+          expect(request.headers.get('Authorization')).to.equal(null);
         });
       });
 


### PR DESCRIPTION
* Added support for the Request and URL classes
  within fetch interceptors

closes #98