### PR TITLE
fix: remove `popup` as a valid `loginType`

### DIFF
--- a/src/salte-auth.js
+++ b/src/salte-auth.js
@@ -380,13 +380,11 @@ class SalteAuth {
 
     this.$promises.token = Promise.resolve();
     if (this.profile.idTokenExpired) {
-      if (this.$config.loginType === 'popup') {
-        this.$promises.token = this.loginWithPopup();
-      } else if ([undefined, null, 'iframe'].indexOf(this.$config.loginType) !== -1) {
+      if ([undefined, null, 'iframe'].indexOf(this.$config.loginType) !== -1) {
         this.$promises.token = this.loginWithIframe();
       } else {
         this.$promises.token = null;
-        return Promise.reject(new ReferenceError(`Invaid Login Type (${this.$config.loginType})`));
+        return Promise.reject(new ReferenceError(`Invalid Login Type (${this.$config.loginType})`));
       }
     }
 

--- a/tests/salte-auth/salte-auth.spec.js
+++ b/tests/salte-auth/salte-auth.spec.js
@@ -920,23 +920,6 @@ describe('salte-auth', () => {
         expect(error.code).to.equal('login_canceled');
       });
     });
-
-    it('should handle the login being blocked', () => {
-      auth.$config.loginType = 'popup';
-
-      sandbox
-        .stub(auth, 'loginWithPopup')
-        .returns(Promise.reject('Popup blocked!'));
-      sandbox.stub(auth.profile, 'idTokenExpired').get(() => true);
-
-      const promise = auth.retrieveAccessToken();
-
-      expect(auth.$promises.token).to.equal(promise);
-      return promise.catch(error => {
-        expect(error).to.deep.equal('Popup blocked!');
-        expect(auth.$promises.token).to.equal(null);
-      });
-    });
   });
 
   describe('function($$onRouteChanged)', () => {

--- a/tests/salte-auth/salte-auth.spec.js
+++ b/tests/salte-auth/salte-auth.spec.js
@@ -852,29 +852,6 @@ describe('salte-auth', () => {
       });
     });
 
-    it('should support using a popup to auto login', () => {
-      auth.$config.loginType = 'popup';
-
-      sandbox.stub(auth, 'loginWithPopup').returns(Promise.resolve());
-      sandbox.stub(auth.profile, 'idTokenExpired').get(() => true);
-      sandbox.stub(auth.profile, 'accessTokenExpired').get(() => true);
-      sandbox.stub(auth.profile, '$clearErrors');
-      sandbox.stub(auth.profile, '$validate');
-      sandbox.stub(auth.$utilities, 'createIframe').returns(Promise.resolve());
-
-      const promise = auth.retrieveAccessToken();
-
-      auth.profile.$accessToken = '55555-55555';
-
-      expect(auth.$promises.token).to.equal(promise);
-      return promise.then(accessToken => {
-        expect(auth.loginWithPopup.callCount).to.equal(1);
-        expect(auth.profile.$clearErrors.callCount).to.equal(1);
-        expect(accessToken).to.equal('55555-55555');
-        expect(auth.$promises.token).to.equal(null);
-      });
-    });
-
     it('should bypass fetching the tokens if they have not expired', () => {
       sandbox.stub(auth.profile, 'idTokenExpired').get(() => false);
       sandbox.stub(auth.profile, 'accessTokenExpired').get(() => false);
@@ -905,7 +882,7 @@ describe('salte-auth', () => {
           return error;
         })
         .then(error => {
-          expect(error.message).to.equal('Invaid Login Type (redirect)');
+          expect(error.message).to.equal('Invalid Login Type (redirect)');
           expect(auth.$promises.token).to.equal(null);
         });
     });


### PR DESCRIPTION
### Why isn't this a Breaking Change?

* The functionality never worked and never would have worked consistently.
  * 99.9% of browsers require a user event in order for `window.open` to work properly.
  This is to prevent a developer from opening numerous windows on the end-users machine.
* The functionality was never publicly documented.

### Related Issues

closes #144 
