### PR TITLE
feat: added support for event listeners

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,10 +77,6 @@
                     'https://jsonplaceholder.typicode.com/posts/1'
                 ],
 
-                redirectLoginCallback: function(error) {
-                    console.log(error);
-                },
-
                 provider
             });
 
@@ -90,6 +86,22 @@
             }
 
             var auth = new salte.SalteAuth(config);
+
+            auth.on('login', function(error, user) {
+                if (error) {
+                    console.error(error);
+                } else {
+                    console.log(user);
+                }
+            });
+
+            auth.on('logout', function(error, user) {
+                if (error) {
+                    console.error(error);
+                } else {
+                    console.log(user);
+                }
+            });
 
             document.querySelector('#login').addEventListener('click', function() {
                 var type = document.querySelector('[name="type"]:checked').value;

--- a/src/salte-auth.profile.js
+++ b/src/salte-auth.profile.js
@@ -213,6 +213,21 @@ class SalteAuthProfile {
   }
 
   /**
+   * Sets or Gets an action based on whether a action was passed.
+   * @param {String} state The state this action is tied to.
+   * @param {String} action The action to store.
+   * @return {String|undefined} Returns a string if an action wasn't provided.
+   * @private
+   */
+  $actions(state, action) {
+    if (action) {
+      this.$saveItem(`salte.auth.action.${state}`, action);
+    } else {
+      return this.$storage.getItem(`salte.auth.action.${state}`);
+    }
+  }
+
+  /**
    * Parses the User Info from the ID Token
    * @return {Object} The User Info from the ID Token
    */

--- a/tests/salte-auth/salte-auth.spec.js
+++ b/tests/salte-auth/salte-auth.spec.js
@@ -12,6 +12,8 @@ describe('salte-auth', () => {
     sandbox = sinon.sandbox.create();
     sandbox.stub(uuid, 'v4').returns('33333333-3333-4333-b333-333333333333');
     sandbox.stub(window, 'setTimeout');
+    // NOTE: Stubbing console so we don't get spammed.
+    sandbox.stub(console, 'warn');
     // NOTE: We're just stubbing these so we can restore it later!
     sandbox.stub(window, 'fetch').callThrough();
     sandbox.stub(XMLHttpRequest.prototype, 'open').callThrough();
@@ -166,9 +168,9 @@ describe('salte-auth', () => {
           expect(redirectUrl).to.equal(undefined);
         });
 
-        delete window.salte.auth;
+      delete window.salte.auth;
 
-        auth = new SalteAuth({
+      auth = new SalteAuth({
         provider: 'auth0',
         redirectLoginCallback: error => {
           expect(error).to.deep.equal(undefined);
@@ -177,6 +179,70 @@ describe('salte-auth', () => {
       });
 
       expect(location.href).to.equal(url);
+    });
+
+    it('should fire off a "login" event if we failed to login via a redirect', () => {
+      window.setTimeout.restore();
+
+      sandbox.stub(SalteAuthProfile.prototype, '$validate').returns({
+        code: 'stuff_broke',
+        description: 'what did you break!'
+      });
+      sandbox.stub(SalteAuthProfile.prototype, '$redirectUrl').get(() => 'error');
+      sandbox.stub(SalteAuthProfile.prototype, '$state').get(() => 'bogus');
+
+      delete window.salte.auth;
+
+      auth = new SalteAuth({
+        provider: 'auth0'
+      });
+
+      auth.profile.$actions('bogus', 'login');
+
+      return new Promise((resolve, reject) => {
+        auth.on('login', (error) => {
+          if (error) return resolve(error);
+
+          return reject('Promise unexpectedly resolved');
+        });
+      }).then((error) => {
+        expect(error).to.deep.equal({
+          code: 'stuff_broke',
+          description: 'what did you break!'
+        });
+      });
+    });
+
+    it('should fire off a "logout" event if we failed to logout via a redirect', () => {
+      window.setTimeout.restore();
+
+      sandbox.stub(SalteAuthProfile.prototype, '$validate').returns({
+        code: 'stuff_broke',
+        description: 'what did you break!'
+      });
+      sandbox.stub(SalteAuthProfile.prototype, '$redirectUrl').get(() => 'error');
+      sandbox.stub(SalteAuthProfile.prototype, '$state').get(() => 'bogus');
+
+      delete window.salte.auth;
+
+      auth = new SalteAuth({
+        provider: 'auth0'
+      });
+
+      auth.profile.$actions('bogus', 'logout');
+
+      return new Promise((resolve, reject) => {
+        auth.on('logout', (error) => {
+          if (error) return resolve(error);
+
+          return reject('Promise unexpectedly resolved');
+        });
+      }).then((error) => {
+        expect(error).to.deep.equal({
+          code: 'stuff_broke',
+          description: 'what did you break!'
+        });
+      });
     });
 
     it('should validate for errors when redirecting', done => {
@@ -432,6 +498,50 @@ describe('salte-auth', () => {
     });
   });
 
+  describe('function(on)', () => {
+    it('should register a listener', () => {
+      const reference = function() {};
+      auth.on('login', reference);
+
+      expect(auth.$listeners).to.deep.equal({
+        login: [reference]
+      });
+    });
+
+    it('should throw an error if an invalid event type is provided', () => {
+      expect(() => auth.on('bogus')).to.throw(ReferenceError);
+    });
+
+    it('should throw an error if an invalid callback is provided', () => {
+      expect(() => auth.on('login')).to.throw(ReferenceError);
+    });
+  });
+
+  describe('function(off)', () => {
+    it('should deregister a listener', () => {
+      const reference = function() {};
+      auth.on('login', reference);
+
+      expect(auth.$listeners).to.deep.equal({
+        login: [reference]
+      });
+
+      auth.off('login', reference);
+
+      expect(auth.$listeners).to.deep.equal({
+        login: []
+      });
+    });
+
+    it('should throw an error if an invalid event type is provided', () => {
+      expect(() => auth.off('bogus')).to.throw(ReferenceError);
+    });
+
+    it('should throw an error if an invalid callback is provided', () => {
+      expect(() => auth.off('login')).to.throw(ReferenceError);
+    });
+  });
+
   describe('function(loginWithIframe)', () => {
     beforeEach(() => {
       auth.profile.$clear();
@@ -451,8 +561,56 @@ describe('salte-auth', () => {
 
       expect(auth.profile.$clear.callCount).to.equal(1);
       expect(auth.$promises.login).to.equal(promise);
-      return promise.then(() => {
+      return promise.then((user) => {
+        expect(user).to.deep.equal(auth.profile.userInfo);
         expect(auth.$promises.login).to.equal(null);
+      });
+    });
+
+    it('should fire off a "login" event when successful', () => {
+      const promise = new Promise((resolve, reject) => {
+        auth.on('login', (error, user) => {
+          if (error) return reject(error);
+
+          return resolve(user);
+        });
+      });
+
+      sandbox.stub(auth.profile, '$validate');
+
+      sandbox.stub(auth.profile, '$idToken').get(() => `0.${btoa(
+        JSON.stringify({
+          sub: '1234567890',
+          name: 'John Doe'
+        })
+      )}.0`);
+
+      auth.loginWithIframe();
+
+      return promise.then((user) => {
+        expect(user).to.deep.equal(auth.profile.userInfo);
+      });
+    });
+
+    it('should fire off a "login" event on failures', () => {
+      const promise = new Promise((resolve, reject) => {
+        auth.on('login', (error, user) => {
+          if (error) return resolve(error);
+
+          return Promise.reject('Promise unexpectedly resolved.');
+        });
+      });
+
+      sandbox.stub(auth, '$loginUrl').get(() => '');
+      auth.$utilities.createIframe.restore();
+      sandbox
+        .stub(auth.$utilities, 'createIframe')
+        .returns(Promise.reject('Iframe Failed!'));
+
+      auth.loginWithIframe();
+
+      return promise.then((error) => {
+        expect(error).to.equal('Iframe Failed!');
       });
     });
 
@@ -515,9 +673,69 @@ describe('salte-auth', () => {
       expect(auth.profile.$clear.callCount).to.equal(1);
       expect(auth.$promises.login).to.equal(promise);
       expect(auth.profile.$$transfer.callCount).to.equal(0);
-      return promise.then(() => {
+
+      return promise.then((user) => {
+        expect(user).to.deep.equal(auth.profile.userInfo);
         expect(auth.profile.$$transfer.callCount).to.equal(1);
         expect(auth.$promises.login).to.equal(null);
+      });
+    });
+
+    it('should fire off a "login" event when successful', () => {
+      const promise = new Promise((resolve, reject) => {
+        auth.on('login', (error, user) => {
+          if (error) return reject(error);
+
+          return resolve(user);
+        });
+      });
+
+      sandbox.stub(auth.profile, '$clear');
+      sandbox.stub(auth, '$loginUrl').get(() => '');
+      sandbox.stub(auth.$utilities, 'openPopup').returns(Promise.resolve());
+      sandbox.stub(auth.profile, '$validate');
+      sandbox.stub(auth.profile, '$$transfer');
+
+      sandbox.stub(auth.profile, '$idToken').get(() => `0.${btoa(
+        JSON.stringify({
+          sub: '1234567890',
+          name: 'John Doe'
+        })
+      )}.0`);
+
+      auth.loginWithPopup();
+
+      return promise.then((user) => {
+        expect(user).to.deep.equal(auth.profile.userInfo);
+      });
+    });
+
+    it('should fire off a "login" event on failures', () => {
+      const promise = new Promise((resolve, reject) => {
+        auth.on('login', (error, user) => {
+          if (error) return resolve(error);
+
+          return Promise.reject('Promise unexpectedly resolved.');
+        });
+      });
+
+      sandbox.stub(auth.profile, '$clear');
+      sandbox.stub(auth, '$loginUrl').get(() => '');
+      sandbox
+        .stub(auth.$utilities, 'openPopup')
+        .returns(Promise.reject('Popup blocked!'));
+
+      auth.profile.$idToken = `0.${btoa(
+        JSON.stringify({
+          sub: '1234567890',
+          name: 'John Doe'
+        })
+      )}.0`;
+
+      auth.loginWithPopup();
+
+      return promise.then((error) => {
+        expect(error).to.equal('Popup blocked!');
       });
     });
 
@@ -612,9 +830,69 @@ describe('salte-auth', () => {
       expect(auth.profile.$clear.callCount).to.equal(1);
       expect(auth.$promises.login).to.equal(promise);
       expect(auth.profile.$$transfer.callCount).to.equal(0);
-      return promise.then(() => {
+
+      return promise.then((user) => {
+        expect(user).to.deep.equal(auth.profile.userInfo);
         expect(auth.profile.$$transfer.callCount).to.equal(1);
         expect(auth.$promises.login).to.equal(null);
+      });
+    });
+
+    it('should fire off a "login" event when successful', () => {
+      const promise = new Promise((resolve, reject) => {
+        auth.on('login', (error, user) => {
+          if (error) return reject(error);
+
+          return resolve(user);
+        });
+      });
+
+      sandbox.stub(auth.profile, '$clear');
+      sandbox.stub(auth, '$loginUrl').get(() => '');
+      sandbox.stub(auth.$utilities, 'openNewTab').returns(Promise.resolve());
+      sandbox.stub(auth.profile, '$validate');
+      sandbox.stub(auth.profile, '$$transfer');
+
+      sandbox.stub(auth.profile, '$idToken').get(() => `0.${btoa(
+        JSON.stringify({
+          sub: '1234567890',
+          name: 'John Doe'
+        })
+      )}.0`);
+
+      auth.loginWithNewTab();
+
+      return promise.then((user) => {
+        expect(user).to.deep.equal(auth.profile.userInfo);
+      });
+    });
+
+    it('should fire off a "login" event on failures', () => {
+      const promise = new Promise((resolve, reject) => {
+        auth.on('login', (error, user) => {
+          if (error) return resolve(error);
+
+          return Promise.reject('Promise unexpectedly resolved.');
+        });
+      });
+
+      sandbox.stub(auth.profile, '$clear');
+      sandbox.stub(auth, '$loginUrl').get(() => '');
+      sandbox
+        .stub(auth.$utilities, 'openNewTab')
+        .returns(Promise.reject('New Tab blocked!'));
+
+      sandbox.stub(auth.profile, '$idToken').get(() => `0.${btoa(
+        JSON.stringify({
+          sub: '1234567890',
+          name: 'John Doe'
+        })
+      )}.0`);
+
+      auth.loginWithNewTab();
+
+      return promise.then((error) => {
+        expect(error).to.equal('New Tab blocked!');
       });
     });
 
@@ -724,8 +1002,14 @@ describe('salte-auth', () => {
       expect(auth.profile.$redirectUrl).to.equal(location.href);
     });
 
-    it('should require a "redirectLoginCallback" to be provided', () => {
-      expect(() => auth.loginWithRedirect()).to.throw(ReferenceError);
+    it('should log a deprecation warning if the user utilizes "redirectLoginCallback".', () => {
+      auth.$config.redirectLoginCallback = sandbox.stub();
+
+      expect(console.warn.callCount).to.equal(0);
+
+      auth.loginWithRedirect();
+
+      expect(console.warn.callCount).to.equal(1);
     });
   });
 
@@ -744,6 +1028,44 @@ describe('salte-auth', () => {
       });
     });
 
+    it('should fire off a "logout" event when successful', () => {
+      const promise = new Promise((resolve, reject) => {
+        auth.on('logout', (error, user) => {
+          if (error) return reject(error);
+
+          return resolve(user);
+        });
+      });
+
+      sandbox.stub(auth.profile, '$clear');
+      sandbox.stub(auth, '$deauthorizeUrl').get(() => '');
+      sandbox.stub(auth.$utilities, 'createIframe').returns(Promise.resolve());
+
+      auth.logoutWithIframe();
+
+      return promise;
+    });
+
+    it('should fire off a "logout" event on failures', () => {
+      const promise = new Promise((resolve, reject) => {
+        auth.on('logout', (error, user) => {
+          if (error) return resolve(error);
+
+          return Promise.reject('Promise unexpectedly resolved.');
+        });
+      });
+
+      sandbox.stub(auth.profile, '$clear');
+      sandbox.stub(auth, '$deauthorizeUrl').get(() => '');
+      sandbox.stub(auth.$utilities, 'createIframe').returns(Promise.reject('Iframe blocked!'));
+
+      auth.logoutWithIframe();
+
+      return promise.then((error) => {
+        expect(error).to.equal('Iframe blocked!');
+      });
+    });
+
     it('should prevent duplicate promises', () => {
       sandbox.stub(auth.profile, '$clear');
       sandbox.stub(auth, '$deauthorizeUrl').get(() => '');
@@ -755,6 +1077,17 @@ describe('salte-auth', () => {
       expect(promise).to.equal(duplicatePromise);
 
       return promise;
+    });
+
+    it('should support failures', () => {
+      sandbox.stub(auth.profile, '$clear');
+      sandbox.stub(auth, '$deauthorizeUrl').get(() => '');
+      sandbox.stub(auth.$utilities, 'createIframe').returns(Promise.reject('Iframe blocked!'));
+
+      return auth.logoutWithIframe().catch((error) => error).then((error) => {
+        expect(error).to.equal('Iframe blocked!');
+        expect(auth.$promises.logout).to.equal(null);
+      });
     });
   });
 
@@ -773,6 +1106,44 @@ describe('salte-auth', () => {
       });
     });
 
+    it('should fire off a "logout" event when successful', () => {
+      const promise = new Promise((resolve, reject) => {
+        auth.on('logout', (error, user) => {
+          if (error) return reject(error);
+
+          return resolve(user);
+        });
+      });
+
+      sandbox.stub(auth.profile, '$clear');
+      sandbox.stub(auth, '$deauthorizeUrl').get(() => '');
+      sandbox.stub(auth.$utilities, 'openPopup').returns(Promise.resolve());
+
+      auth.logoutWithPopup();
+
+      return promise;
+    });
+
+    it('should fire off a "logout" event on failures', () => {
+      const promise = new Promise((resolve, reject) => {
+        auth.on('logout', (error, user) => {
+          if (error) return resolve(error);
+
+          return Promise.reject('Promise unexpectedly resolved.');
+        });
+      });
+
+      sandbox.stub(auth.profile, '$clear');
+      sandbox.stub(auth, '$deauthorizeUrl').get(() => '');
+      sandbox.stub(auth.$utilities, 'openPopup').returns(Promise.reject('Popup blocked!'));
+
+      auth.logoutWithPopup();
+
+      return promise.then((error) => {
+        expect(error).to.equal('Popup blocked!');
+      });
+    });
+
     it('should prevent duplicate promises', () => {
       sandbox.stub(auth.profile, '$clear');
       sandbox.stub(auth, '$deauthorizeUrl').get(() => '');
@@ -785,6 +1156,17 @@ describe('salte-auth', () => {
       expect(promise).to.equal(duplicatePromise);
 
       return promise;
+    });
+
+    it('should support failures', () => {
+      sandbox.stub(auth.profile, '$clear');
+      sandbox.stub(auth, '$deauthorizeUrl').get(() => '');
+      sandbox.stub(auth.$utilities, 'openPopup').returns(Promise.reject('Popup blocked!'));
+
+      return auth.logoutWithPopup().catch((error) => error).then((error) => {
+        expect(error).to.equal('Popup blocked!');
+        expect(auth.$promises.logout).to.equal(null);
+      });
     });
   });
 
@@ -803,6 +1185,44 @@ describe('salte-auth', () => {
       });
     });
 
+    it('should fire off a "logout" event when successful', () => {
+      const promise = new Promise((resolve, reject) => {
+        auth.on('logout', (error, user) => {
+          if (error) return reject(error);
+
+          return resolve(user);
+        });
+      });
+
+      sandbox.stub(auth.profile, '$clear');
+      sandbox.stub(auth, '$deauthorizeUrl').get(() => '');
+      sandbox.stub(auth.$utilities, 'openNewTab').returns(Promise.resolve());
+
+      auth.logoutWithNewTab();
+
+      return promise;
+    });
+
+    it('should fire off a "logout" event on failures', () => {
+      const promise = new Promise((resolve, reject) => {
+        auth.on('logout', (error, user) => {
+          if (error) return resolve(error);
+
+          return Promise.reject('Promise unexpectedly resolved.');
+        });
+      });
+
+      sandbox.stub(auth.profile, '$clear');
+      sandbox.stub(auth, '$deauthorizeUrl').get(() => '');
+      sandbox.stub(auth.$utilities, 'openNewTab').returns(Promise.reject('New Tab blocked!'));
+
+      auth.logoutWithNewTab();
+
+      return promise.then((error) => {
+        expect(error).to.equal('New Tab blocked!');
+      });
+    });
+
     it('should prevent duplicate promises', () => {
       sandbox.stub(auth.profile, '$clear');
       sandbox.stub(auth, '$deauthorizeUrl').get(() => '');
@@ -815,6 +1235,17 @@ describe('salte-auth', () => {
       expect(promise).to.equal(duplicatePromise);
 
       return promise;
+    });
+
+    it('should support failures', () => {
+      sandbox.stub(auth.profile, '$clear');
+      sandbox.stub(auth, '$deauthorizeUrl').get(() => '');
+      sandbox.stub(auth.$utilities, 'openNewTab').returns(Promise.reject('New Tab blocked!'));
+
+      return auth.logoutWithNewTab().catch((error) => error).then((error) => {
+        expect(error).to.equal('New Tab blocked!');
+        expect(auth.$promises.logout).to.equal(null);
+      });
     });
   });
 


### PR DESCRIPTION
* Added an api for listening for login and logout events.
* All of the login functions (excluding redirect) return the `userInfo` object.
* Fixed a bug where failed logout attempts wouldn't
  clear the logout promise.

closes #150 