### PR TITLE
fix: automatic renewal should take page visibility into account

### DIFF
--- a/src/salte-auth.js
+++ b/src/salte-auth.js
@@ -137,9 +137,33 @@ class SalteAuth {
         }
       });
 
-      window.addEventListener('popstate', this.$$onRouteChanged.bind(this));
-      document.addEventListener('click', this.$$onRouteChanged.bind(this));
+      window.addEventListener('popstate', this.$$onRouteChanged.bind(this), { passive: true });
+      document.addEventListener('click', this.$$onRouteChanged.bind(this), { passive: true });
       setTimeout(this.$$onRouteChanged.bind(this));
+
+      this.on('login', (error, user) => {
+        if (error) return;
+
+        this.$$refreshToken();
+      });
+
+      this.on('refresh', (error, user) => {
+        if (error) return;
+
+        this.$$refreshToken();
+      });
+
+      this.on('logout', (error, user) => {
+        clearTimeout(this.$timeouts.refresh);
+      });
+
+      if (!this.profile.idTokenExpired) {
+        this.$$refreshToken();
+      }
+
+      window.addEventListener('visibilitychange', this.$$onVisibilityChanged.bind(this), {
+        passive: true
+      });
     }
 
     // TODO(v3.0.0): Revoke singleton status from `salte-auth`.
@@ -147,26 +171,6 @@ class SalteAuth {
 
     if (this.$config.redirectLoginCallback) {
       console.warn(`The "redirectLoginCallback" api has been deprecated in favor of the "on" api, see http://bit.ly/salte-auth-on for more info.`);
-    }
-
-    this.on('login', (error, user) => {
-      if (error) return;
-
-      this.$$refreshToken();
-    });
-
-    this.on('refresh', (error, user) => {
-      if (error) return;
-
-      this.$$refreshToken();
-    });
-
-    this.on('logout', (error, user) => {
-      clearTimeout(this.$timeouts.refresh);
-    });
-
-    if (!this.profile.idTokenExpired) {
-      this.$$refreshToken();
     }
   }
 
@@ -666,6 +670,23 @@ class SalteAuth {
     if (!this.$utilities.isRouteSecure(location.href, this.$config.routes)) return;
 
     this.retrieveAccessToken();
+  }
+
+  /**
+   * Disables automatic refresh of the token if the page is no longer visible
+   * @ignore
+   */
+  $$onVisibilityChanged() {
+    if (this.profile.idTokenExpired) return;
+
+    if (document.hidden) {
+      this.refreshToken().then(() => {
+        clearTimeout(this.$timeouts.refresh);
+        this.$timeouts.refresh = null;
+      });
+    } else {
+      this.$$refreshToken();
+    }
   }
 }
 

--- a/src/salte-auth.utilities.js
+++ b/src/salte-auth.utilities.js
@@ -219,7 +219,7 @@ class SalteAuthUtilities {
     return new Promise((resolve) => {
       iframe.addEventListener('DOMNodeRemoved', () => {
         setTimeout(resolve);
-      });
+      }, { passive: true });
     });
   }
 

--- a/tests/salte-auth/utilities/add-xhr-interceptor.spec.js
+++ b/tests/salte-auth/utilities/add-xhr-interceptor.spec.js
@@ -27,7 +27,7 @@ describe('function(addXHRInterceptor)', () => {
             'This is the execution context.'
           );
           resolve();
-        });
+        }, { passive: true });
       })
     );
 
@@ -48,7 +48,7 @@ describe('function(addXHRInterceptor)', () => {
         request.addEventListener('error', event => {
           expect(event.detail).to.equal('Stuff broke!');
           resolve();
-        });
+        }, { passive: true });
       })
     );
     request.open('GET', `${location.protocol}//${location.host}/context.html`, false);


### PR DESCRIPTION
### Description

This change renews a users session and disables the automatic renewal 
introduced in v2.3.0 when the page is no longer visible.

This gives them the best possible chance of their session 
not expiring while also not letting it live forever.

closes #171 