### PR TITLE
fix: salte-io tokens get cleared on refresh

### DIFF
--- a/src/salte-auth.js
+++ b/src/salte-auth.js
@@ -695,20 +695,23 @@ class SalteAuth {
    * @ignore
    */
   $$onVisibilityChanged() {
-    logger('Visibility change detected, determining if the id token has expired...');
-    if (this.profile.idTokenExpired) return;
+    logger('Visibility change detected, deferring to the next event loop...');
+    setTimeout(() => {
+      logger('Determining if the id token has expired...');
+      if (this.profile.idTokenExpired) return;
 
-    if (this.$utilities.$hidden) {
-      logger('Page is hidden, refreshing the token...');
-      this.refreshToken().then(() => {
-        logger('Disabling automatic renewal of the token...');
-        clearTimeout(this.$timeouts.refresh);
-        this.$timeouts.refresh = null;
-      });
-    } else {
-      logger('Page is visible restarting automatic token renewal...');
-      this.$$refreshToken();
-    }
+      if (this.$utilities.$hidden) {
+        logger('Page is hidden, refreshing the token...');
+        this.refreshToken().then(() => {
+          logger('Disabling automatic renewal of the token...');
+          clearTimeout(this.$timeouts.refresh);
+          this.$timeouts.refresh = null;
+        });
+      } else {
+        logger('Page is visible restarting automatic token renewal...');
+        this.$$refreshToken();
+      }
+    });
   }
 }
 

--- a/src/salte-auth.profile.js
+++ b/src/salte-auth.profile.js
@@ -25,8 +25,8 @@ class SalteAuthProfile {
       storageType: 'session'
     });
     if (location.hash) {
-      logger(`Hash detected, parsing... (${location.hash})`);
       const params = location.hash.replace(/(#!?[^#]+)?#/, '').split('&');
+      logger(`Hash detected, parsing...`, params);
       for (let i = 0; i < params.length; i++) {
         const param = params[i];
         const [key, value] = param.split('=');

--- a/tests/salte-auth/salte-auth.spec.js
+++ b/tests/salte-auth/salte-auth.spec.js
@@ -1673,6 +1673,8 @@ describe('salte-auth', () => {
     it('should refresh the token if we hide the page', () => {
       const promise = Promise.resolve();
 
+      window.setTimeout.restore();
+      sandbox.stub(window, 'setTimeout').callsFake((cb) => cb());
       sandbox.stub(auth, '$$refreshToken');
       sandbox.stub(auth, 'refreshToken').returns(promise);
       sandbox.stub(auth.profile, 'idTokenExpired').get(() => false);
@@ -1693,6 +1695,8 @@ describe('salte-auth', () => {
     it('should reactivate the automatic refresh when the page is shown', () => {
       const promise = Promise.resolve();
 
+      window.setTimeout.restore();
+      sandbox.stub(window, 'setTimeout').callsFake((cb) => cb());
       sandbox.stub(auth, '$$refreshToken');
       sandbox.stub(auth, 'refreshToken').returns(promise);
       sandbox.stub(auth.profile, 'idTokenExpired').get(() => false);


### PR DESCRIPTION
* `$$onVisibilityChange` will now defer to the next event loop
before performing any functionality. This will prevent it from
stepping on location changes and refreshes

closes #179