### PR TITLE
feat: invoke a create event when salte-auth finishes instantiating

### DIFF
--- a/src/salte-auth.js
+++ b/src/salte-auth.js
@@ -179,6 +179,8 @@ class SalteAuth {
       document.addEventListener('visibilitychange', this.$$onVisibilityChanged.bind(this), {
         passive: true
       });
+
+      this.$fire('create', null, this);
     }
 
     // TODO(v3.0.0): Revoke singleton status from `salte-auth`.

--- a/tests/salte-auth/salte-auth.spec.js
+++ b/tests/salte-auth/salte-auth.spec.js
@@ -47,6 +47,26 @@ describe('salte-auth', () => {
       expect(window.salte.auth).to.be.undefined;
     });
 
+    it('should fire off a create event', () => {
+      const promise = new Promise((resolve, reject) => {
+        window.addEventListener('salte-auth-create', (event) => {
+          if (event.detail.error) return reject(event.detail.error);
+
+          return resolve(event.detail.data);
+        });
+      });
+
+      delete window.salte.auth;
+
+      auth = new SalteAuth({
+        provider: 'auth0'
+      });
+
+      return promise.then((instance) => {
+        expect(instance).to.equal(auth);
+      });
+    });
+
     it('should default loginType, storageType, and validation', () => {
       delete window.salte.auth;
 


### PR DESCRIPTION
* Purposely didn't add this to the Event Listener whitelist because
its impossible to listen for this event via the `on` api.

closes #189