### PR TITLE
fix: store validation variables via localStorage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,11 @@ cache:
   yarn: true
   directories:
     - node_modules
-branches:
-  only:
-    - master
-    - /^greenkeeper/.*$/
+# TODO: Remove this before merging!
+# branches:
+#   only:
+#     - master
+#     - /^greenkeeper/.*$/
 script:
   - yarn start lint
   - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then yarn start test.sauce; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,10 @@ cache:
   yarn: true
   directories:
     - node_modules
-# TODO: Remove this before merging!
-# branches:
-#   only:
-#     - master
-#     - /^greenkeeper/.*$/
+branches:
+  only:
+    - master
+    - /^greenkeeper/.*$/
 script:
   - yarn start lint
   - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then yarn start test.sauce; fi

--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
     };
 
     var queryParams = Object.assign({
-      provider: sessionStorage.getItem('salte.demo.provider') || 'auth0',
+      provider: localStorage.getItem('salte.demo.provider') || 'auth0',
       'login-type': 'redirect',
       secured: 'not-secured'
     }, location.search.replace(/^\?/, '').split('&').reduce(function(r, a) {
@@ -220,9 +220,9 @@
       });
     }
 
-    if (queryParams.provider !== sessionStorage.getItem('salte.demo.provider')) {
-      sessionStorage.clear();
-      sessionStorage.setItem('salte.demo.provider', queryParams.provider);
+    if (queryParams.provider !== localStorage.getItem('salte.demo.provider')) {
+      localStorage.clear();
+      localStorage.setItem('salte.demo.provider', queryParams.provider);
     }
 
     var auth = new salte.SalteAuth(config);

--- a/tests/salte-auth/salte-auth.profile.spec.js
+++ b/tests/salte-auth/salte-auth.profile.spec.js
@@ -16,6 +16,7 @@ describe('salte-auth.profile', () => {
 
   describe('function(constructor)', () => {
     beforeEach(() => {
+      localStorage.clear();
       sessionStorage.clear();
     });
 
@@ -150,7 +151,7 @@ describe('salte-auth.profile', () => {
   describe('setter(redirectUrl)', () => {
     it('should set sessionStorage', () => {
       profile.$redirectUrl = location.href;
-      expect(sessionStorage.getItem('salte.auth.$redirect-url')).to.equal(
+      expect(localStorage.getItem('salte.auth.$redirect-url')).to.equal(
         location.href
       );
     });
@@ -407,6 +408,11 @@ describe('salte-auth.profile', () => {
       expect(sessionStorage.getItem('bogus')).to.equal('bogus');
     });
 
+    it('should allow overriding the default storage', () => {
+      profile.$saveItem('bogus', 'bogus', 'local');
+      expect(localStorage.getItem('bogus')).to.equal('bogus');
+    });
+
     it('should allow other falsy values', () => {
       profile.$saveItem('bogus', '');
       expect(sessionStorage.getItem('bogus')).to.equal('');
@@ -420,6 +426,23 @@ describe('salte-auth.profile', () => {
     it('should delete items from sessionStorage when undefined', () => {
       profile.$saveItem('bogus', undefined);
       expect(sessionStorage.getItem('bogus')).to.equal(null);
+    });
+  });
+
+  describe('function($getItem)', () => {
+    it('should save to sessionStorage', () => {
+      profile.$saveItem('bogus', 'bogus');
+      expect(profile.$getItem('bogus')).to.equal('bogus');
+    });
+
+    it('should return null if the value does not exist', () => {
+      profile.$saveItem('bogus', null);
+      expect(profile.$getItem('bogus')).to.equal(null);
+    });
+
+    it('should support overriding the default storage', () => {
+      profile.$saveItem('bogus', '', 'local');
+      expect(profile.$getItem('bogus', 'local')).to.equal(localStorage.getItem('bogus'));
     });
   });
 
@@ -479,6 +502,35 @@ describe('salte-auth.profile', () => {
       expect(sessionStorage.getItem('error_description')).to.equal(
         'Look what you did!'
       );
+    });
+  });
+
+  describe('function($$transfer)', () => {
+    beforeEach(() => {
+      profile.$idToken = '12345-12345-12345';
+      profile.$state = '1234';
+    });
+
+    afterEach(() => {
+      profile.$clear();
+    });
+
+    it('should transfer salte variables between storage', () => {
+      profile.$$transfer('session', 'local');
+
+      expect(sessionStorage.getItem('salte.auth.id-token')).to.equal(null);
+      expect(localStorage.getItem('salte.auth.id-token')).to.equal('12345-12345-12345');
+      expect(sessionStorage.getItem('salte.auth.$state')).to.equal(null);
+      expect(localStorage.getItem('salte.auth.$state')).to.equal('1234');
+    });
+
+    it('should avoid transfering validation variables', () => {
+      profile.$$transfer('local', 'session');
+
+      expect(sessionStorage.getItem('salte.auth.id-token')).to.equal('12345-12345-12345');
+      expect(localStorage.getItem('salte.auth.id-token')).to.equal(null);
+      expect(sessionStorage.getItem('salte.auth.$state')).to.equal(null);
+      expect(localStorage.getItem('salte.auth.$state')).to.equal('1234');
     });
   });
 });


### PR DESCRIPTION
* ie 11 was wiping out sessionStorage variables upon redirect,
instead we're going to store validation
variables in localStorage while still respecting the
users desire to save token variables via their chosen storage.

closes #193 