### PR TITLE
fix: tabbing between screens in the same app results in validation errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,10 @@
       <option value="tab">New Tab</option>
       <option value="iframe">Iframe</option>
     </select>
+    <select id="storage-type" name="storage-type">
+      <option value="session">Session Storage</option>
+      <option value="local">Local Storage</option>
+    </select>
     <select id="secured" name="secured">
       <option value="not-secured">Not Secured</option>
       <option value="all-routes">Secure All Routes</option>
@@ -107,6 +111,7 @@
     var elements = {
       provider: document.getElementById('provider'),
       loginType: document.getElementById('login-type'),
+      storageType: document.getElementById('storage-type'),
       secured: document.getElementById('secured'),
       footer: document.getElementById('footer'),
       userInfo: document.getElementById('user-info'),
@@ -143,6 +148,7 @@
     var queryParams = Object.assign({
       provider: localStorage.getItem('salte.demo.provider') || 'auth0',
       'login-type': 'redirect',
+      'storage-type': localStorage.getItem('salte.demo.storage-type') || 'session',
       secured: 'not-secured'
     }, location.search.replace(/^\?/, '').split('&').reduce(function(r, a) {
       var match = a.match(/([^=]+)(?:=([^&]+))?/);
@@ -160,6 +166,7 @@
 
     elements.provider.value = queryParams.provider;
     elements.loginType.value = queryParams['login-type'];
+    elements.storageType.value = queryParams['storage-type'];
     elements.secured.value = queryParams.secured;
 
     function updateParamsOnChange() {
@@ -197,6 +204,7 @@
 
     elements.provider.addEventListener('change', updateParamsOnChange);
     elements.loginType.addEventListener('change', updateParamsOnChange);
+    elements.storageType.addEventListener('change', updateParamsOnChange);
     elements.secured.addEventListener('change', updateParamsOnChange);
 
     var config = Object.assign(configs[queryParams.provider], {
@@ -205,7 +213,9 @@
 
       provider: queryParams.provider,
 
-      loginType: 'redirect'
+      loginType: 'redirect',
+
+      storageType: queryParams['storage-type']
     });
 
     if (['all', 'all-routes'].includes(queryParams.secured)) {
@@ -223,6 +233,10 @@
     if (queryParams.provider !== localStorage.getItem('salte.demo.provider')) {
       localStorage.clear();
       localStorage.setItem('salte.demo.provider', queryParams.provider);
+    }
+
+    if (queryParams['storage-type'] !== localStorage.getItem('salte.demo.storage-type')) {
+      localStorage.setItem('salte.demo.storage-type', queryParams['storage-type']);
     }
 
     var auth = new salte.SalteAuth(config);

--- a/src/salte-auth.js
+++ b/src/salte-auth.js
@@ -97,7 +97,7 @@ class SalteAuth {
      * @type {SalteAuthUtilities}
      * @private
      */
-    this.$utilities = new SalteAuthUtilities();
+    this.$utilities = new SalteAuthUtilities(this.$config);
 
     /**
      * The user profile for salte auth
@@ -110,13 +110,6 @@ class SalteAuth {
       parent.document.body.removeChild(this.$utilities.$iframe);
     } else if (this.$utilities.$popup) {
       logger('Popup detected!');
-      // We need to utilize local storage to retain our parsed values
-      if (this.$config.storageType === 'session') {
-        logger('Transfering from session to local storage...');
-        this.profile.$$transfer('session', 'local');
-      }
-      logger('Closing popup...');
-      setTimeout(this.$utilities.$popup.close);
     } else if (this.profile.$redirectUrl && location.href !== this.profile.$redirectUrl) {
       logger('Redirect detected!');
       const error = this.profile.$validate();
@@ -441,10 +434,7 @@ class SalteAuth {
     this.profile.$clear();
     this.$promises.login = this.$utilities.openPopup(this.$loginUrl()).then(() => {
       this.$promises.login = null;
-      // We need to utilize local storage to retain our parsed values
-      if (this.$config.storageType === 'session') {
-        this.profile.$$transfer('local', 'session');
-      }
+      this.profile.$hash();
       const error = this.profile.$validate();
 
       if (error) {
@@ -483,10 +473,7 @@ class SalteAuth {
     this.profile.$clear();
     this.$promises.login = this.$utilities.openNewTab(this.$loginUrl()).then(() => {
       this.$promises.login = null;
-      // We need to utilize local storage to retain our parsed values
-      if (this.$config.storageType === 'session') {
-        this.profile.$$transfer('local', 'session');
-      }
+      this.profile.$hash();
       const error = this.profile.$validate();
 
       if (error) {

--- a/src/salte-auth.profile.js
+++ b/src/salte-auth.profile.js
@@ -24,6 +24,13 @@ class SalteAuthProfile {
       },
       storageType: 'session'
     });
+    this.$hash();
+  }
+
+  /**
+   * Check for a hash, parses it, and removes it.
+   */
+  $hash() {
     if (location.hash) {
       const params = location.hash.replace(/(#!?[^#]+)?#/, '').split('&');
       logger(`Hash detected, parsing...`, params);
@@ -32,6 +39,8 @@ class SalteAuthProfile {
         const [key, value] = param.split('=');
         this.$parse(key, decodeURIComponent(value));
       }
+      logger(`Removing hash...`);
+      history.pushState('', document.title, location.href.split('#')[0]);
     }
   }
 
@@ -89,11 +98,11 @@ class SalteAuthProfile {
    * @private
    */
   get $tokenType() {
-    return this.$getItem('salte.auth.$token-type', 'local');
+    return this.$getItem('salte.auth.$token-type', 'session');
   }
 
   set $tokenType(tokenType) {
-    this.$saveItem('salte.auth.$token-type', tokenType, 'local');
+    this.$saveItem('salte.auth.$token-type', tokenType, 'session');
   }
 
   /**
@@ -143,11 +152,11 @@ class SalteAuthProfile {
    * @see https://tools.ietf.org/html/rfc6749#section-4.1.1
    */
   get $state() {
-    return this.$getItem('salte.auth.$state', 'local');
+    return this.$getItem('salte.auth.$state', 'session');
   }
 
   set $state(state) {
-    this.$saveItem('salte.auth.$state', state, 'local');
+    this.$saveItem('salte.auth.$state', state, 'session');
   }
 
   /**
@@ -158,11 +167,11 @@ class SalteAuthProfile {
    * @see https://tools.ietf.org/html/rfc6749#section-4.1.1
    */
   get $localState() {
-    return this.$getItem('salte.auth.$local-state', 'local');
+    return this.$getItem('salte.auth.$local-state', 'session');
   }
 
   set $localState(localState) {
-    this.$saveItem('salte.auth.$local-state', localState, 'local');
+    this.$saveItem('salte.auth.$local-state', localState, 'session');
   }
 
   /**
@@ -197,11 +206,11 @@ class SalteAuthProfile {
    * @private
    */
   get $redirectUrl() {
-    return this.$getItem('salte.auth.$redirect-url', 'local');
+    return this.$getItem('salte.auth.$redirect-url', 'session');
   }
 
   set $redirectUrl(redirectUrl) {
-    this.$saveItem('salte.auth.$redirect-url', redirectUrl, 'local');
+    this.$saveItem('salte.auth.$redirect-url', redirectUrl, 'session');
   }
 
   /**
@@ -210,11 +219,11 @@ class SalteAuthProfile {
    * @private
    */
   get $nonce() {
-    return this.$getItem('salte.auth.$nonce', 'local');
+    return this.$getItem('salte.auth.$nonce', 'session');
   }
 
   set $nonce(nonce) {
-    this.$saveItem('salte.auth.$nonce', nonce, 'local');
+    this.$saveItem('salte.auth.$nonce', nonce, 'session');
   }
 
   /**
@@ -380,37 +389,19 @@ class SalteAuthProfile {
   }
 
   /**
-   * Transfers values from one storage type to the other
-   * @param {String} source the name of the storage type to pull from
-   * @param {String} destination the name of the storage type to push to
-   * @ignore
-   */
-  $$transfer(source, destination) {
-    const sourceStorage = this.$$getStorage(source);
-    const destinationStorage = this.$$getStorage(destination);
-
-    for (const key in sourceStorage) {
-      if (!key.match(/^salte\.auth\.[^$]/)) continue;
-
-      destinationStorage.setItem(key, sourceStorage.getItem(key));
-      sourceStorage.removeItem(key);
-    }
-  }
-
-  /**
    * Clears all `salte.auth` values from localStorage
    * @private
    */
   $clear() {
     for (const key in localStorage) {
       if (key.match(/^salte\.auth\.[^$]/)) {
-        this.$saveItem(key, undefined);
+        localStorage.removeItem(key);
       }
     }
 
     for (const key in sessionStorage) {
       if (key.match(/^salte\.auth\.[^$]/)) {
-        this.$saveItem(key, undefined);
+        sessionStorage.removeItem(key);
       }
     }
   }

--- a/src/salte-auth.utilities.js
+++ b/src/salte-auth.utilities.js
@@ -9,8 +9,12 @@ const logger = debug('@salte-io/salte-auth:utilities');
 class SalteAuthUtilities {
   /**
    * Wraps all XHR and Fetch (if available) requests to allow promise interceptors
+   * @param {Config} config configuration for salte auth
    */
-  constructor() {
+  constructor(config) {
+    /** @ignore */
+    this.$$config = config;
+
     /** @ignore */
     this.$interceptors = {
       fetch: [],
@@ -158,9 +162,15 @@ class SalteAuthUtilities {
     // TODO: Find a better way of tracking when a Window closes.
     return new Promise((resolve) => {
       const checker = setInterval(() => {
-        if (!popupWindow.closed) return;
-        clearInterval(checker);
-        setTimeout(resolve);
+        try {
+          // This could throw cross-domain errors, so we need to silence them.
+          if (popupWindow.location.href.indexOf(this.$$config.redirectUrl) !== 0) return;
+
+          location.hash = popupWindow.location.hash;
+          popupWindow.close();
+          clearInterval(checker);
+          setTimeout(resolve);
+        } catch (e) {}
       }, 100);
     });
   }
@@ -181,9 +191,15 @@ class SalteAuthUtilities {
     // TODO: Find a better way of tracking when a Window closes.
     return new Promise((resolve) => {
       const checker = setInterval(() => {
-        if (!tabWindow.closed) return;
-        clearInterval(checker);
-        setTimeout(resolve);
+        try {
+          // This could throw cross-domain errors, so we need to silence them.
+          if (tabWindow.location.href.indexOf(this.$$config.redirectUrl) !== 0) return;
+
+          location.hash = tabWindow.location.hash;
+          tabWindow.close();
+          clearInterval(checker);
+          setTimeout(resolve);
+        } catch (e) {}
       }, 100);
     });
   }

--- a/tests/salte-auth/salte-auth.profile.spec.js
+++ b/tests/salte-auth/salte-auth.profile.spec.js
@@ -151,7 +151,7 @@ describe('salte-auth.profile', () => {
   describe('setter(redirectUrl)', () => {
     it('should set sessionStorage', () => {
       profile.$redirectUrl = location.href;
-      expect(localStorage.getItem('salte.auth.$redirect-url')).to.equal(
+      expect(sessionStorage.getItem('salte.auth.$redirect-url')).to.equal(
         location.href
       );
     });
@@ -240,6 +240,8 @@ describe('salte-auth.profile', () => {
     });
 
     it('should return an error if the "local-state" does not match the "state"', () => {
+      profile.$localState = '54321';
+      profile.$state = '12345';
       profile.$idToken = `0.${btoa(
         JSON.stringify({
           sub: '1234567890',
@@ -464,14 +466,26 @@ describe('salte-auth.profile', () => {
   });
 
   describe('function($clear)', () => {
-    beforeEach(() => {
+    it('should remove all "salte.auth" items from localStorage', () => {
+      localStorage.setItem('salte.auth.$test', '123');
+      localStorage.setItem('salte.auth.id_token', '12345-12345-12345');
+      localStorage.setItem('salte.auth.bogus', '12345');
+      localStorage.setItem('bogus', '12345');
+
+      profile.$clear();
+
+      expect(localStorage.getItem('salte.auth.$test')).to.equal('123');
+      expect(localStorage.getItem('salte.auth.id_token')).to.equal(null);
+      expect(localStorage.getItem('salte.auth.bogus')).to.equal(null);
+      expect(localStorage.getItem('bogus')).to.equal('12345');
+    });
+
+    it('should remove all "salte.auth" items from sessionStorage', () => {
       sessionStorage.setItem('salte.auth.$test', '123');
       sessionStorage.setItem('salte.auth.id_token', '12345-12345-12345');
       sessionStorage.setItem('salte.auth.bogus', '12345');
       sessionStorage.setItem('bogus', '12345');
-    });
 
-    it('should remove all "salte.auth" items from sessionStorage', () => {
       profile.$clear();
 
       expect(sessionStorage.getItem('salte.auth.$test')).to.equal('123');
@@ -502,35 +516,6 @@ describe('salte-auth.profile', () => {
       expect(sessionStorage.getItem('error_description')).to.equal(
         'Look what you did!'
       );
-    });
-  });
-
-  describe('function($$transfer)', () => {
-    beforeEach(() => {
-      profile.$idToken = '12345-12345-12345';
-      profile.$state = '1234';
-    });
-
-    afterEach(() => {
-      profile.$clear();
-    });
-
-    it('should transfer salte variables between storage', () => {
-      profile.$$transfer('session', 'local');
-
-      expect(sessionStorage.getItem('salte.auth.id-token')).to.equal(null);
-      expect(localStorage.getItem('salte.auth.id-token')).to.equal('12345-12345-12345');
-      expect(sessionStorage.getItem('salte.auth.$state')).to.equal(null);
-      expect(localStorage.getItem('salte.auth.$state')).to.equal('1234');
-    });
-
-    it('should avoid transfering validation variables', () => {
-      profile.$$transfer('local', 'session');
-
-      expect(sessionStorage.getItem('salte.auth.id-token')).to.equal('12345-12345-12345');
-      expect(localStorage.getItem('salte.auth.id-token')).to.equal(null);
-      expect(sessionStorage.getItem('salte.auth.$state')).to.equal(null);
-      expect(localStorage.getItem('salte.auth.$state')).to.equal('1234');
     });
   });
 });

--- a/tests/salte-auth/salte-auth.spec.js
+++ b/tests/salte-auth/salte-auth.spec.js
@@ -914,17 +914,17 @@ describe('salte-auth', () => {
       sandbox.stub(auth, '$loginUrl').returns('');
       sandbox.stub(auth.$utilities, 'openPopup').returns(Promise.resolve());
       sandbox.stub(auth.profile, '$validate');
-      sandbox.stub(auth.profile, '$$transfer');
+      sandbox.stub(auth.profile, '$hash');
 
       const promise = auth.loginWithPopup();
 
       expect(auth.profile.$clear.callCount).to.equal(1);
       expect(auth.$promises.login).to.equal(promise);
-      expect(auth.profile.$$transfer.callCount).to.equal(0);
+      expect(auth.profile.$hash.callCount).to.equal(0);
 
       return promise.then((user) => {
         expect(user).to.deep.equal(auth.profile.userInfo);
-        expect(auth.profile.$$transfer.callCount).to.equal(1);
+        expect(auth.profile.$hash.callCount).to.equal(1);
         expect(auth.$promises.login).to.equal(null);
       });
     });
@@ -942,7 +942,7 @@ describe('salte-auth', () => {
       sandbox.stub(auth, '$loginUrl').returns('');
       sandbox.stub(auth.$utilities, 'openPopup').returns(Promise.resolve());
       sandbox.stub(auth.profile, '$validate');
-      sandbox.stub(auth.profile, '$$transfer');
+      sandbox.stub(auth.profile, '$hash');
 
       sandbox.stub(auth.profile, '$idToken').get(() => `0.${btoa(
         JSON.stringify({
@@ -984,25 +984,6 @@ describe('salte-auth', () => {
 
       return promise.then((error) => {
         expect(error).to.equal('Popup blocked!');
-      });
-    });
-
-    it('should bypass transfering storage when using "localStorage"', () => {
-      sandbox.stub(auth.profile, '$clear');
-      sandbox.stub(auth, '$loginUrl').returns('');
-      sandbox.stub(auth.$utilities, 'openPopup').returns(Promise.resolve());
-      sandbox.stub(auth.profile, '$validate');
-      sandbox.stub(auth.profile, '$$transfer');
-
-      auth.$config.storageType = 'local';
-
-      const promise = auth.loginWithPopup();
-
-      expect(auth.profile.$clear.callCount).to.equal(1);
-      expect(auth.$promises.login).to.equal(promise);
-      return promise.then(() => {
-        expect(auth.profile.$$transfer.callCount).to.equal(0);
-        expect(auth.$promises.login).to.equal(null);
       });
     });
 
@@ -1079,17 +1060,17 @@ describe('salte-auth', () => {
       sandbox.stub(auth, '$loginUrl').returns('');
       sandbox.stub(auth.$utilities, 'openNewTab').returns(Promise.resolve());
       sandbox.stub(auth.profile, '$validate');
-      sandbox.stub(auth.profile, '$$transfer');
+      sandbox.stub(auth.profile, '$hash');
 
       const promise = auth.loginWithNewTab();
 
       expect(auth.profile.$clear.callCount).to.equal(1);
       expect(auth.$promises.login).to.equal(promise);
-      expect(auth.profile.$$transfer.callCount).to.equal(0);
+      expect(auth.profile.$hash.callCount).to.equal(0);
 
       return promise.then((user) => {
         expect(user).to.deep.equal(auth.profile.userInfo);
-        expect(auth.profile.$$transfer.callCount).to.equal(1);
+        expect(auth.profile.$hash.callCount).to.equal(1);
         expect(auth.$promises.login).to.equal(null);
       });
     });
@@ -1107,7 +1088,7 @@ describe('salte-auth', () => {
       sandbox.stub(auth, '$loginUrl').returns('');
       sandbox.stub(auth.$utilities, 'openNewTab').returns(Promise.resolve());
       sandbox.stub(auth.profile, '$validate');
-      sandbox.stub(auth.profile, '$$transfer');
+      sandbox.stub(auth.profile, '$hash');
 
       sandbox.stub(auth.profile, '$idToken').get(() => `0.${btoa(
         JSON.stringify({
@@ -1149,25 +1130,6 @@ describe('salte-auth', () => {
 
       return promise.then((error) => {
         expect(error).to.equal('New Tab blocked!');
-      });
-    });
-
-    it('should bypass transfering storage when using "localStorage"', () => {
-      sandbox.stub(auth.profile, '$clear');
-      sandbox.stub(auth, '$loginUrl').returns('');
-      sandbox.stub(auth.$utilities, 'openNewTab').returns(Promise.resolve());
-      sandbox.stub(auth.profile, '$validate');
-      sandbox.stub(auth.profile, '$$transfer');
-
-      auth.$config.storageType = 'local';
-
-      const promise = auth.loginWithNewTab();
-
-      expect(auth.profile.$clear.callCount).to.equal(1);
-      expect(auth.$promises.login).to.equal(promise);
-      return promise.then(() => {
-        expect(auth.profile.$$transfer.callCount).to.equal(0);
-        expect(auth.$promises.login).to.equal(null);
       });
     });
 

--- a/tests/salte-auth/utilities/open-popup.spec.js
+++ b/tests/salte-auth/utilities/open-popup.spec.js
@@ -5,7 +5,9 @@ import SalteAuthUtilities from '../../../src/salte-auth.utilities.js';
 describe('function(openPopup)', () => {
   let sandbox, utilities;
   beforeEach(() => {
-    utilities = new SalteAuthUtilities();
+    utilities = new SalteAuthUtilities({
+      redirectUrl: 'https://redirect-url'
+    });
     sandbox = sinon.createSandbox();
   });
 
@@ -19,16 +21,21 @@ describe('function(openPopup)', () => {
       focus: sandbox.stub(),
       close: function() {
         this.closed = true;
+      },
+      location: {
+        href: 'https://incorrect-redirect-url'
       }
     });
 
-    const promise = utilities.openPopup('https://www.google.com');
-
     setTimeout(() => {
-      window.open.firstCall.returnValue.close();
+      sandbox.stub(window.open.firstCall.returnValue, 'location').get(() => {
+        return {
+          href: 'https://redirect-url'
+        };
+      });
     }, 200);
 
-    return promise;
+    return utilities.openPopup('https://www.google.com');
   });
 
   it('should handle blocked popups', () => {


### PR DESCRIPTION
* validation should be bound to a users session
* transfer the hash to the parent window and parse
  it locally to prevent storage issues

closes #197, closes #168, closes #166