### PR TITLE
fix: access token expiration should be converted to milliseconds

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
     var configs = {
       auth0: {
         providerUrl: 'https://salte-alpha.auth0.com',
-        responseType: 'id_token',
+        responseType: 'id_token token',
         clientId: 'mM6h2LHJikwdbkvdoiyE8kHhL7gcV8Wb'
       },
 

--- a/src/salte-auth.profile.js
+++ b/src/salte-auth.profile.js
@@ -56,7 +56,7 @@ class SalteAuthProfile {
         this.$tokenType = value;
         break;
       case 'expires_in':
-        this.$expiration = Date.now() + value;
+        this.$expiration = Date.now() + (Number(value) * 1000);
         break;
       case 'access_token':
         this.$accessToken = value;
@@ -107,11 +107,12 @@ class SalteAuthProfile {
 
   /**
    * The date and time that the access token will expire
-   * @return {String} the expiration time as unix timestamp
+   * @return {Number} the expiration time as unix timestamp
    * @private
    */
   get $expiration() {
-    return this.$getItem('salte.auth.expiration');
+    const expiration = this.$getItem('salte.auth.expiration');
+    return expiration ? Number(expiration) : null;
   }
 
   set $expiration(expiration) {

--- a/tests/salte-auth/salte-auth.profile.spec.js
+++ b/tests/salte-auth/salte-auth.profile.spec.js
@@ -51,7 +51,7 @@ describe('salte-auth.profile', () => {
     it('should parse the expires_in', () => {
       sandbox.useFakeTimers();
       profile.$parse('expires_in', 5000);
-      expect(profile.$expiration).to.equal('5000');
+      expect(profile.$expiration).to.equal(5000000);
     });
 
     it('should parse the access_token', () => {
@@ -125,6 +125,7 @@ describe('salte-auth.profile', () => {
   describe('getter(accessTokenExpired)', () => {
     beforeEach(() => {
       profile.$accessToken = '55555-555555';
+      profile.$parse('expires_in', '1');
     });
 
     it('should be expired if the "access_token" is empty', () => {
@@ -133,11 +134,15 @@ describe('salte-auth.profile', () => {
     });
 
     it('should be expired if the "expiration" is in the past', () => {
-      expect(profile.accessTokenExpired).to.equal(true);
+      expect(profile.accessTokenExpired).to.equal(false);
+      return new Promise((resolve) => {
+        setTimeout(resolve, 1000);
+      }).then(() => {
+        expect(profile.accessTokenExpired).to.equal(true);
+      });
     });
 
     it('should not be expired if the "access_token" is present and the "expiration" is in the future', () => {
-      profile.$expiration = Date.now() + 100;
       expect(profile.accessTokenExpired).to.equal(false);
     });
   });


### PR DESCRIPTION
* fixed an issue where the access token expiration was computed incorrectly
* access token expiration is now returned as a number

closes #200