### PR TITLE
feat: some providers allow for separate login and logout urls

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,10 @@
       <option value="tab">New Tab</option>
       <option value="iframe">Iframe</option>
     </select>
+    <select id="redirect-url" name="redirect-url">
+      <option value="single">Single</option>
+      <option value="separate">Separate Login and Logout</option>
+    </select>
     <select id="storage-type" name="storage-type">
       <option value="session">Session Storage</option>
       <option value="local">Local Storage</option>
@@ -111,6 +115,7 @@
     var elements = {
       provider: document.getElementById('provider'),
       loginType: document.getElementById('login-type'),
+      redirectUrl: document.getElementById('redirect-url'),
       storageType: document.getElementById('storage-type'),
       secured: document.getElementById('secured'),
       footer: document.getElementById('footer'),
@@ -148,6 +153,7 @@
     var queryParams = Object.assign({
       provider: localStorage.getItem('salte.demo.provider') || 'auth0',
       'login-type': 'redirect',
+      'redirect-url': 'single',
       'storage-type': localStorage.getItem('salte.demo.storage-type') || 'session',
       secured: 'not-secured'
     }, location.search.replace(/^\?/, '').split('&').reduce(function(r, a) {
@@ -166,6 +172,7 @@
 
     elements.provider.value = queryParams.provider;
     elements.loginType.value = queryParams['login-type'];
+    elements.redirectUrl.value = queryParams['redirect-url'];
     elements.storageType.value = queryParams['storage-type'];
     elements.secured.value = queryParams.secured;
 
@@ -204,11 +211,16 @@
 
     elements.provider.addEventListener('change', updateParamsOnChange);
     elements.loginType.addEventListener('change', updateParamsOnChange);
+    elements.redirectUrl.addEventListener('change', updateParamsOnChange);
     elements.storageType.addEventListener('change', updateParamsOnChange);
     elements.secured.addEventListener('change', updateParamsOnChange);
 
     var config = Object.assign(configs[queryParams.provider], {
-      redirectUrl: location.protocol + '//' + location.host,
+      redirectUrl: queryParams['redirect-url'] === 'single' ? location.protocol + '//' + location.host : {
+        loginUrl: location.protocol + '//' + location.host,
+        logoutUrl: location.protocol + '//' + location.host
+      },
+
       scope: 'openid',
 
       provider: queryParams.provider,

--- a/src/providers/auth0.js
+++ b/src/providers/auth0.js
@@ -10,7 +10,7 @@ class SalteAuthAuth0Provider {
    */
   static deauthorizeUrl(config) {
     return this.$utilities.createUrl(`${config.providerUrl}/v2/logout`, {
-      returnTo: config.redirectUrl,
+      returnTo: config.redirectUrl && config.redirectUrl.logoutUrl || config.redirectUrl,
       client_id: config.clientId
     });
   }

--- a/src/providers/azure.js
+++ b/src/providers/azure.js
@@ -16,7 +16,7 @@ class SalteAuthAzureProvider {
    */
   static deauthorizeUrl(config) {
     return this.$utilities.createUrl(`${config.providerUrl}/oauth2/logout`, {
-      post_logout_redirect_uri: config.redirectUrl
+      post_logout_redirect_uri: config.redirectUrl && config.redirectUrl.logoutUrl || config.redirectUrl
     });
   }
 }

--- a/src/providers/cognito.js
+++ b/src/providers/cognito.js
@@ -16,7 +16,7 @@ class SalteAuthCognitoProvider {
    */
   static deauthorizeUrl(config) {
     return this.$utilities.createUrl(`${config.providerUrl}/logout`, {
-      logout_uri: config.redirectUrl,
+      logout_uri: config.redirectUrl && config.redirectUrl.logoutUrl || config.redirectUrl,
       client_id: config.clientId
     });
   }

--- a/src/providers/wso2.js
+++ b/src/providers/wso2.js
@@ -9,7 +9,7 @@ class SalteAuthWSO2Provider {
     return this.$utilities.createUrl(`${config.providerUrl}/commonauth`, {
       commonAuthLogout: true,
       type: 'oidc',
-      commonAuthCallerPath: config.redirectUrl,
+      commonAuthCallerPath: config.redirectUrl && config.redirectUrl.logoutUrl || config.redirectUrl,
       relyingParty: config.relyingParty
     });
   }

--- a/src/salte-auth.js
+++ b/src/salte-auth.js
@@ -9,6 +9,7 @@ import { Providers } from './salte-auth.providers.js';
 import { SalteAuthProfile } from './salte-auth.profile.js';
 import { SalteAuthUtilities } from './salte-auth.utilities.js';
 
+/** @ignore */
 const logger = debug('@salte-io/salte-auth');
 
 /**

--- a/src/salte-auth.js
+++ b/src/salte-auth.js
@@ -21,11 +21,18 @@ const logger = debug('@salte-io/salte-auth');
  */
 
 /**
+ * Disable certain security validations if your provider doesn't support them.
+ * @typedef {Object} RedirectURLs
+ * @property {String} [loginUrl] The redirect url specified in your identity provider for logging in.
+ * @property {String} [logoutUrl] The redirect url specified in your identity provider for logging out.
+ */
+
+/**
  * The configuration for salte auth
  * @typedef {Object} Config
  * @property {String} providerUrl The base url of your identity provider.
  * @property {('id_token'|'id_token token')} responseType The response type to authenticate with.
- * @property {String} redirectUrl The redirect url specified in your identity provider.
+ * @property {String|RedirectURLs} redirectUrl The redirect url specified in your identity provider.
  * @property {String} clientId The client id of your identity provider
  * @property {String} scope A list of space-delimited claims used to determine what user information is provided and what access is given. Most providers require 'openid'.
  * @property {Boolean|Array<String>} routes A list of secured routes. If true is provided then all routes are secured.
@@ -233,7 +240,7 @@ class SalteAuth {
       'state': this.profile.$localState,
       'nonce': this.profile.$nonce,
       'response_type': 'token',
-      'redirect_uri': this.$config.redirectUrl,
+      'redirect_uri': this.$config.redirectUrl && this.$config.redirectUrl.loginUrl || this.$config.redirectUrl,
       'client_id': this.$config.clientId,
       'scope': this.$config.scope,
       'prompt': 'none'
@@ -259,7 +266,7 @@ class SalteAuth {
       'state': this.profile.$localState,
       'nonce': this.profile.$nonce,
       'response_type': this.$config.responseType,
-      'redirect_uri': this.$config.redirectUrl,
+      'redirect_uri': this.$config.redirectUrl && this.$config.redirectUrl.loginUrl || this.$config.redirectUrl,
       'client_id': this.$config.clientId,
       'scope': this.$config.scope,
       'prompt': refresh ? 'none' : undefined
@@ -653,7 +660,6 @@ class SalteAuth {
 
     return this.$promises.token;
   }
-
   /**
    * Registers a timeout that will automatically refresh the id token
    */

--- a/src/salte-auth.profile.js
+++ b/src/salte-auth.profile.js
@@ -2,6 +2,7 @@ import defaultsDeep from 'lodash/defaultsDeep';
 import find from 'lodash/find';
 import debug from 'debug';
 
+/** @ignore */
 const logger = debug('@salte-io/salte-auth:profile');
 
 /**

--- a/src/salte-auth.utilities.js
+++ b/src/salte-auth.utilities.js
@@ -164,7 +164,9 @@ class SalteAuthUtilities {
       const checker = setInterval(() => {
         try {
           // This could throw cross-domain errors, so we need to silence them.
-          if (popupWindow.location.href.indexOf(this.$$config.redirectUrl) !== 0) return;
+          const loginUrl = this.$$config.redirectUrl && this.$$config.redirectUrl.loginUrl || this.$$config.redirectUrl;
+          const logoutUrl = this.$$config.redirectUrl && this.$$config.redirectUrl.logoutUrl || this.$$config.redirectUrl;
+          if (popupWindow.location.href.indexOf(loginUrl) !== 0 || popupWindow.location.href.indexOf(logoutUrl) !== 0) return;
 
           location.hash = popupWindow.location.hash;
           popupWindow.close();
@@ -193,7 +195,9 @@ class SalteAuthUtilities {
       const checker = setInterval(() => {
         try {
           // This could throw cross-domain errors, so we need to silence them.
-          if (tabWindow.location.href.indexOf(this.$$config.redirectUrl) !== 0) return;
+          const loginUrl = this.$$config.redirectUrl && this.$$config.redirectUrl.loginUrl || this.$$config.redirectUrl;
+          const logoutUrl = this.$$config.redirectUrl && this.$$config.redirectUrl.logoutUrl || this.$$config.redirectUrl;
+          if (tabWindow.location.href.indexOf(loginUrl) !== 0 || tabWindow.location.href.indexOf(logoutUrl) !== 0) return;
 
           location.hash = tabWindow.location.hash;
           tabWindow.close();

--- a/src/salte-auth.utilities.js
+++ b/src/salte-auth.utilities.js
@@ -1,6 +1,7 @@
 import assign from 'lodash/assign';
 import debug from 'debug';
 
+/** @ignore */
 const logger = debug('@salte-io/salte-auth:utilities');
 
 /**

--- a/tests/salte-auth/providers/auth0.spec.js
+++ b/tests/salte-auth/providers/auth0.spec.js
@@ -15,5 +15,16 @@ describe('auth0', () => {
       });
       expect(url).to.equal(`https://api.salte.io/v2/logout?returnTo=${encodeURIComponent(`${location.protocol}//${location.host}`)}&client_id=33333333-3333-4333-b333-333333333333`);
     });
+
+    it('should support a separate logoutUrl', () => {
+      const url = auth0.deauthorizeUrl.call({ $utilities: utilities }, {
+        providerUrl: 'https://api.salte.io',
+        redirectUrl: {
+          logoutUrl: `${location.protocol}//${location.host}`
+        },
+        clientId: '33333333-3333-4333-b333-333333333333'
+      });
+      expect(url).to.equal(`https://api.salte.io/v2/logout?returnTo=${encodeURIComponent(`${location.protocol}//${location.host}`)}&client_id=33333333-3333-4333-b333-333333333333`);
+    });
   });
 });

--- a/tests/salte-auth/providers/azure.spec.js
+++ b/tests/salte-auth/providers/azure.spec.js
@@ -22,5 +22,16 @@ describe('azure', () => {
       });
       expect(url).to.equal(`https://login.microsoftonline.com/my-tenant/oauth2/logout?post_logout_redirect_uri=${encodeURIComponent(`${location.protocol}//${location.host}`)}`);
     });
+
+    it('should support a separate logoutUrl', () => {
+      const url = azure.deauthorizeUrl.call({ $utilities: utilities }, {
+        providerUrl: 'https://login.microsoftonline.com/my-tenant',
+        redirectUrl: {
+          logoutUrl: `${location.protocol}//${location.host}`
+        },
+        clientId: '33333333-3333-4333-b333-333333333333'
+      });
+      expect(url).to.equal(`https://login.microsoftonline.com/my-tenant/oauth2/logout?post_logout_redirect_uri=${encodeURIComponent(`${location.protocol}//${location.host}`)}`);
+    });
   });
 });

--- a/tests/salte-auth/providers/cognito.spec.js
+++ b/tests/salte-auth/providers/cognito.spec.js
@@ -23,6 +23,17 @@ describe('cognito', () => {
       });
       expect(url).to.equal(`https://mydomain.auth.us-east-1.amazoncognito.com/logout?logout_uri=${encodeURIComponent(`${location.protocol}//${location.host}`)}&client_id=33333333-3333-4333-b333-333333333333`);
     });
+
+    it('should support a separate logoutUrl', () => {
+      const url = cognito.deauthorizeUrl.call({ $utilities: utilities }, {
+        providerUrl: 'https://mydomain.auth.us-east-1.amazoncognito.com',
+        redirectUrl: {
+          logoutUrl: `${location.protocol}//${location.host}`
+        },
+        clientId: '33333333-3333-4333-b333-333333333333'
+      });
+      expect(url).to.equal(`https://mydomain.auth.us-east-1.amazoncognito.com/logout?logout_uri=${encodeURIComponent(`${location.protocol}//${location.host}`)}&client_id=33333333-3333-4333-b333-333333333333`);
+    });
   });
 
   describe('getter(defaultConfig)', () => {

--- a/tests/salte-auth/providers/wso2.spec.js
+++ b/tests/salte-auth/providers/wso2.spec.js
@@ -15,5 +15,16 @@ describe('wso2', () => {
       });
       expect(url).to.equal(`https://api.salte.io/commonauth?commonAuthLogout=true&type=oidc&commonAuthCallerPath=${encodeURIComponent(`${location.protocol}//${location.host}`)}&relyingParty=test123`);
     });
+
+    it('should support a separate logoutUrl', () => {
+      const url = wso2.deauthorizeUrl.call({ $utilities: utilities }, {
+        providerUrl: 'https://api.salte.io',
+        redirectUrl: {
+          logoutUrl: `${location.protocol}//${location.host}`
+        },
+        relyingParty: 'test123'
+      });
+      expect(url).to.equal(`https://api.salte.io/commonauth?commonAuthLogout=true&type=oidc&commonAuthCallerPath=${encodeURIComponent(`${location.protocol}//${location.host}`)}&relyingParty=test123`);
+    });
   });
 });

--- a/tests/salte-auth/salte-auth.spec.js
+++ b/tests/salte-auth/salte-auth.spec.js
@@ -505,6 +505,26 @@ describe('salte-auth', () => {
         )}&client_id=Hzl9Rvu_Ws_s1QKIhI2TXi8NZRn672FC&scope=openid&prompt=none`
       );
     });
+
+    it('should support a separate loginUrl', () => {
+      delete window.salte.auth;
+
+      auth = new SalteAuth({
+        providerUrl: 'https://mydomain.auth.us-east-1.amazoncognito.com',
+        redirectUrl: {
+          loginUrl: `${location.protocol}//${location.host}`
+        },
+        clientId: 'Hzl9Rvu_Ws_s1QKIhI2TXi8NZRn672FC',
+        scope: 'openid',
+        provider: 'cognito'
+      });
+
+      expect(auth.$accessTokenUrl).to.equal(
+        `https://mydomain.auth.us-east-1.amazoncognito.com/oauth2/authorize?state=33333333-3333-4333-b333-333333333333&nonce=33333333-3333-4333-b333-333333333333&response_type=token&redirect_uri=${encodeURIComponent(
+          `${location.protocol}//${location.host}`
+        )}&client_id=Hzl9Rvu_Ws_s1QKIhI2TXi8NZRn672FC&scope=openid&prompt=none`
+      );
+    });
   });
 
   describe('function($loginUrl)', () => {
@@ -534,6 +554,27 @@ describe('salte-auth', () => {
         providerUrl: 'https://mydomain.auth.us-east-1.amazoncognito.com',
         responseType: 'id_token',
         redirectUrl: `${location.protocol}//${location.host}`,
+        clientId: 'Hzl9Rvu_Ws_s1QKIhI2TXi8NZRn672FC',
+        scope: 'openid',
+        provider: 'cognito'
+      });
+
+      expect(auth.$loginUrl()).to.equal(
+        `https://mydomain.auth.us-east-1.amazoncognito.com/oauth2/authorize?state=33333333-3333-4333-b333-333333333333&nonce=33333333-3333-4333-b333-333333333333&response_type=id_token&redirect_uri=${encodeURIComponent(
+          `${location.protocol}//${location.host}`
+        )}&client_id=Hzl9Rvu_Ws_s1QKIhI2TXi8NZRn672FC&scope=openid`
+      );
+    });
+
+    it('should support a separate loginUrl', () => {
+      delete window.salte.auth;
+
+      auth = new SalteAuth({
+        providerUrl: 'https://mydomain.auth.us-east-1.amazoncognito.com',
+        responseType: 'id_token',
+        redirectUrl: {
+          loginUrl: `${location.protocol}//${location.host}`
+        },
         clientId: 'Hzl9Rvu_Ws_s1QKIhI2TXi8NZRn672FC',
         scope: 'openid',
         provider: 'cognito'

--- a/tests/salte-auth/utilities/open-new-tab.spec.js
+++ b/tests/salte-auth/utilities/open-new-tab.spec.js
@@ -55,4 +55,42 @@ describe('function(openNewTab)', () => {
       );
     });
   });
+
+  it('should support a separate loginUrl', () => {
+    utilities.$$config.redirectUrl = {
+      loginUrl: 'https://redirect-url'
+    };
+
+    sandbox.stub(window, 'open').returns(null);
+
+    const promise = utilities.openNewTab('https://www.google.com');
+
+    return promise.catch(error => {
+      return error;
+    }).then(error => {
+      expect(error).to.be.instanceof(ReferenceError);
+      expect(error.message).to.equal(
+        'We were unable to open the new tab, its likely that the request was blocked.'
+      );
+    });
+  });
+
+  it('should support a separate logoutUrl', () => {
+    utilities.$$config.redirectUrl = {
+      logoutUrl: 'https://redirect-url'
+    };
+
+    sandbox.stub(window, 'open').returns(null);
+
+    const promise = utilities.openNewTab('https://www.google.com');
+
+    return promise.catch(error => {
+      return error;
+    }).then(error => {
+      expect(error).to.be.instanceof(ReferenceError);
+      expect(error.message).to.equal(
+        'We were unable to open the new tab, its likely that the request was blocked.'
+      );
+    });
+  });
 });

--- a/tests/salte-auth/utilities/open-popup.spec.js
+++ b/tests/salte-auth/utilities/open-popup.spec.js
@@ -52,4 +52,42 @@ describe('function(openPopup)', () => {
       );
     });
   });
+
+  it('should support a separate loginUrl', () => {
+    utilities.$$config.redirectUrl = {
+      loginUrl: 'https://redirect-url'
+    };
+
+    sandbox.stub(window, 'open').returns(null);
+
+    const promise = utilities.openPopup('https://www.google.com');
+
+    return promise.catch(error => {
+      return error;
+    }).then(error => {
+      expect(error).to.be.instanceof(ReferenceError);
+      expect(error.message).to.equal(
+        'We were unable to open the popup window, its likely that the request was blocked.'
+      );
+    });
+  });
+
+  it('should support a separate logoutUrl', () => {
+    utilities.$$config.redirectUrl = {
+      logoutUrl: 'https://redirect-url'
+    };
+
+    sandbox.stub(window, 'open').returns(null);
+
+    const promise = utilities.openPopup('https://www.google.com');
+
+    return promise.catch(error => {
+      return error;
+    }).then(error => {
+      expect(error).to.be.instanceof(ReferenceError);
+      expect(error.message).to.equal(
+        'We were unable to open the popup window, its likely that the request was blocked.'
+      );
+    });
+  });
 });


### PR DESCRIPTION
### Description

Adds support for a separate `loginUrl` and `logoutUrl`.

### Example

```js
const auth = new SalteAuth({
  redirectUrl: {
    loginUrl: 'https://salte.io/app',
    logoutUrl: 'https://salte.io'
  }
  // ...
});
```

closes #222 