### PR TITLE
feat: user-based redirect url override

### DIFF
--- a/src/salte-auth.js
+++ b/src/salte-auth.js
@@ -167,19 +167,19 @@ class SalteAuth {
       setTimeout(this.$$onRouteChanged.bind(this));
 
       logger('Setting up automatic renewal of token...');
-      this.on('login', (error, user) => {
+      this.on('login', (error) => {
         if (error) return;
 
         this.$$refreshToken();
       });
 
-      this.on('refresh', (error, user) => {
+      this.on('refresh', (error) => {
         if (error) return;
 
         this.$$refreshToken();
       });
 
-      this.on('logout', (error, user) => {
+      this.on('logout', () => {
         clearTimeout(this.$timeouts.refresh);
       });
 
@@ -505,12 +505,13 @@ class SalteAuth {
 
   /**
    * Authenticates using the redirect-based OAuth flow.
+   * @param {String} redirectUrl override for the redirect url, by default this will try to redirect the user back where they started.
    * @return {Promise} a promise intended to block future login attempts.
    *
    * @example
    * auth.loginWithRedirect(); // Don't bother with utilizing the promise here, it never resolves.
    */
-  loginWithRedirect() {
+  loginWithRedirect(redirectUrl) {
     if (this.$config.redirectLoginCallback) {
       console.warn(`The "redirectLoginCallback" api has been deprecated in favor of the "on" api, see http://bit.ly/salte-auth-on for more info.`);
     }
@@ -525,7 +526,7 @@ class SalteAuth {
     this.$promises.login = new Promise(() => {});
 
     this.profile.$clear();
-    this.profile.$redirectUrl = this.profile.$redirectUrl || location.href;
+    this.profile.$redirectUrl = redirectUrl || this.profile.$redirectUrl || location.href;
     const url = this.$loginUrl();
 
     this.profile.$actions(this.profile.$localState, 'login');

--- a/tests/salte-auth/salte-auth.spec.js
+++ b/tests/salte-auth/salte-auth.spec.js
@@ -340,6 +340,26 @@ describe('salte-auth', () => {
         expect(auth.$$onVisibilityChanged.callCount).to.equal(1);
       });
     });
+
+    it('should invoke "$$refreshToken" on "refresh"', () => {
+      sandbox.stub(SalteAuth.prototype, '$$refreshToken');
+
+      expect(auth.$$refreshToken.callCount).to.equal(0);
+
+      auth.$fire('refresh');
+
+      expect(auth.$$refreshToken.callCount).to.equal(1);
+    });
+
+    it('should not invoke "$$refreshToken" when "refresh" errors', () => {
+      sandbox.stub(SalteAuth.prototype, '$$refreshToken');
+
+      expect(auth.$$refreshToken.callCount).to.equal(0);
+
+      auth.$fire('refresh', 'error!');
+
+      expect(auth.$$refreshToken.callCount).to.equal(0);
+    });
   });
 
   describe('interceptor(fetch)', () => {
@@ -1276,6 +1296,12 @@ describe('salte-auth', () => {
       auth.loginWithRedirect();
 
       expect(console.warn.callCount).to.equal(1);
+    });
+
+    it('should support overriding the redirectUrl', () => {
+      auth.loginWithRedirect('https://google.com');
+
+      expect(auth.profile.$redirectUrl).to.equal('https://google.com');
     });
   });
 


### PR DESCRIPTION
### Description

This adds the ability for a developer to override the `redirectUrl` that the user will be sent to after authenticating.

closes #229 