### PR TITLE
fix: `loginWithRedirect` detection issue with relative urls

### DIFF
--- a/src/salte-auth.js
+++ b/src/salte-auth.js
@@ -530,7 +530,7 @@ class SalteAuth {
     this.$promises.login = new Promise(() => {});
 
     this.profile.$clear();
-    this.profile.$redirectUrl = redirectUrl || this.profile.$redirectUrl || location.href;
+    this.profile.$redirectUrl = redirectUrl && this.$utilities.resolveUrl(redirectUrl) || this.profile.$redirectUrl || location.href;
     const url = this.$loginUrl();
 
     this.profile.$actions(this.profile.$localState, 'login');

--- a/src/salte-auth.utilities.js
+++ b/src/salte-auth.utilities.js
@@ -105,7 +105,7 @@ class SalteAuthUtilities {
     }
     this.$$urlBase.href = window.location.protocol + '//' + window.location.host;
     this.$$urlAnchor.href = path.replace(/ /g, '%20');
-    return this.$$urlAnchor.href;
+    return this.$$urlAnchor.href.replace(/\/$/, '');
   }
 
   /**

--- a/tests/salte-auth/salte-auth.spec.js
+++ b/tests/salte-auth/salte-auth.spec.js
@@ -1228,10 +1228,16 @@ describe('salte-auth', () => {
       expect(console.warn.callCount).to.equal(1);
     });
 
-    it('should support overriding the redirectUrl', () => {
+    it('should support overriding the redirectUrl with absolute urls', () => {
       auth.loginWithRedirect('https://google.com');
 
       expect(auth.profile.$redirectUrl).to.equal('https://google.com');
+    });
+
+    it('should support overriding the redirectUrl with relative urls', () => {
+      auth.loginWithRedirect('/dashboard');
+
+      expect(auth.profile.$redirectUrl).to.equal(`${window.location.protocol}//${window.location.host}/dashboard`);
     });
   });
 

--- a/tests/salte-auth/utilities/resolve-url.spec.js
+++ b/tests/salte-auth/utilities/resolve-url.spec.js
@@ -8,6 +8,10 @@ describe('function(resolveUrl)', () => {
     utilities = new SalteAuthUtilities();
   });
 
+  it('should support site root urls', () => {
+    expect(utilities.resolveUrl('https://google.com')).to.equal('https://google.com');
+  });
+
   it('should support paths', () => {
     expect(utilities.resolveUrl('/api/test')).to.equal(
       `${window.location.protocol}//${window.location.host}/api/test`


### PR DESCRIPTION
### Description

When a relative url was passed to `loginWithRedirect` it would always redirect to that url since an absolute url would never be equivalent to a relative url.

closes #253 