### PR TITLE
fix: enriched Request object is not being passed to windows fetch

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,7 +6,9 @@ plugins:
 parserOptions:
   sourceType: module
 rules:
-  indent: [2, 2]
+  indent:
+    - error
+    - 2
   compat/compat: 2
   comma-dangle:
     - error

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,6 +6,7 @@ plugins:
 parserOptions:
   sourceType: module
 rules:
+  indent: [2, 2]
   compat/compat: 2
   comma-dangle:
     - error

--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ We also support HTML Imports:
 <link rel="import" href="/bower_components/salte-auth/salte-auth.html">
 ```
 
-## Usage
+## ES6 Usage
 
 ```js
 import { SalteAuth } from '@salte-io/salte-auth';
 
 // Configure SalteAuth with Auth0's url and client id.
-const auth = new salte.SalteAuth({
+const auth = new SalteAuth({
   providerUrl: 'https://salte-alpha.auth0.com',
   responseType: 'id_token',
   redirectUrl: location.origin,
@@ -96,6 +96,41 @@ const auth = new salte.SalteAuth({
 
 // Display an iframe to the user that allows them to login
 auth.loginWithIframe();
+```
+
+## ES5 Usage
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="/node_modules/@salte-io/salte-auth/dist/salte-auth.js"></script>
+    <script>
+      const auth = new salte.SalteAuth({
+        providerUrl: 'https://salte-alpha.auth0.com',
+        responseType: 'id_token',
+        redirectUrl: location.origin,
+        clientId: 'mM6h2LHJikwdbkvdoiyE8kHhL7gcV8Wb',
+        scope: 'openid',
+        
+        routes: [
+          'http://localhost:8080/account'
+        ],
+
+        endpoints: [
+          'https://jsonplaceholder.typicode.com/posts/1'
+        ],
+
+        provider: 'auth0',
+      });
+
+      auth.loginWithIframe();
+    </script>
+  </head>
+  <body>
+    ...
+  </body>
+</html>
 ```
 
 ## Known Issues

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ We also support HTML Imports:
 import { SalteAuth } from '@salte-io/salte-auth';
 
 // Configure SalteAuth with Auth0's url and client id.
-const auth = new SalteAuth({
+const auth = new salte.SalteAuth({
   providerUrl: 'https://salte-alpha.auth0.com',
   responseType: 'id_token',
   redirectUrl: location.origin,

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "esdoc-plugin-require-coverage": "^0.1.2",
     "esdoc-standard-plugin": "^1.0.0",
     "eslint": "^5.0.0",
-    "eslint-config-google": "^0.9.1",
+    "eslint-config-google": "^0.10.0",
     "eslint-plugin-compat": "^2.0.0",
     "eslint-plugin-mocha": "^5.0.0",
     "html-loader": "^0.5.1",
@@ -71,8 +71,8 @@
     "watch": "^1.0.2",
     "webpack": "^4.0.0",
     "webpack-cli": "^3.0.0",
-    "webpack-dev-server": "^3.0.0",
-    "yargs": "^11.0.0"
+    "webpack-dev-server": "^3.1.7",
+    "yargs": "^12.0.2"
   },
   "config": {
     "commitizen": {

--- a/src/salte-auth.utilities.js
+++ b/src/salte-auth.utilities.js
@@ -62,7 +62,7 @@ class SalteAuthUtilities {
             promises.push(interceptor(request));
           }
           return Promise.all(promises).then(() => {
-            return fetch.call(this, input, options);
+            return fetch.call(this, request, options);
           });
         };
       })(fetch);

--- a/src/salte-auth.utilities.js
+++ b/src/salte-auth.utilities.js
@@ -62,7 +62,7 @@ class SalteAuthUtilities {
             promises.push(interceptor(request));
           }
           return Promise.all(promises).then(() => {
-            return fetch.call(this, request, options);
+            return fetch.call(this, request);
           });
         };
       })(fetch);

--- a/tests/salte-auth/utilities/add-fetch-interceptor.spec.js
+++ b/tests/salte-auth/utilities/add-fetch-interceptor.spec.js
@@ -3,10 +3,10 @@ import { expect } from 'chai';
 import SalteAuthUtilities from '../../../src/salte-auth.utilities.js';
 
 describe('function(addFetchInterceptor)', () => {
-  let sandbox, utilities;
+  let sandbox, utilities, windowsFetch;
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    sandbox.stub(window, 'fetch').returns(Promise.resolve());
+    windowsFetch = sandbox.stub(window, 'fetch').returns(Promise.resolve());
     utilities = new SalteAuthUtilities();
   });
 
@@ -28,6 +28,10 @@ describe('function(addFetchInterceptor)', () => {
 
     return fetch(url, {
       method: 'POST'
+    }).then(() => {
+      expect(windowsFetch.calledWith(sinon.match.instanceOf(Request))).to.equal(true);
+      const [request] = windowsFetch.firstCall.args;
+      expect(request.headers.has('Authorization')).to.equal(true);
     });
   });
 


### PR DESCRIPTION
- Added test to verify Request object is passed.
- Added assertion to verify that the Request object contains the Authorization header.
- Updated eslint-config-google dependency and added indent rule configuration to eslint configuration..
- Updated webpack-dev-server dependency.