### PR TITLE
fix(login): login-specific redirectUrls will no longer throw an error

### DIFF
--- a/src/base/provider-oauth2.ts
+++ b/src/base/provider-oauth2.ts
@@ -128,7 +128,7 @@ export class OAuth2Provider extends Provider {
       ...this.config.queryParams && this.config.queryParams('login'),
       client_id: this.config.clientID,
       response_type: responseType,
-      redirect_uri: this.config.redirectUrl,
+      redirect_uri: this.redirectUrl('login'),
       scope: this.config.scope,
       state,
     });

--- a/test/unit/base/provider-oauth2.spec.js
+++ b/test/unit/base/provider-oauth2.spec.js
@@ -354,6 +354,37 @@ describe('OAuth2Provider', () => {
       expect(params.state).to.match(/^example-state-.+/);
     });
 
+    it(`should support redirectUrl as an object`, () => {
+      const expectedRedirectUrl = 'https://google.com/auth';
+      class Example extends OAuth2Provider {
+        get name() {
+          return 'example';
+        }
+
+        get login() {
+          return 'https://google.com';
+        }
+      };
+
+      const example = new Example({
+        clientID: '12345',
+        responseType: 'token',
+        scope: 'hello',
+
+        redirectUrl: {
+          login: expectedRedirectUrl,
+        },
+      });
+
+      const params = getParams(example.$login());
+
+      expect(params.client_id).to.equal('12345');
+      expect(params.response_type).to.equal('token');
+      expect(params.redirect_uri).to.equal(encodeURIComponent(expectedRedirectUrl));
+      expect(params.scope).to.equal('hello');
+      expect(params.state).to.match(/^example-state-.+/);
+    });
+
     it('should support providing overrides', () => {
       class Example extends OAuth2Provider {
         get name() {


### PR DESCRIPTION
### Description

Passing a `redirectUrl` object to the provider config results in an error upon login.

### Example

```js
// ...

const auth = new SalteAuth({
  provider: [
    new Auth0({
      // ...
      redirectUrl: {
        login: 'https://google.com/login',
        logout: 'https://google.com/logout',
      }
    })
  ],

  // ...
});

// This would throw an error when attempting to attach the `redirect_uri` to the request.
auth.login('auth0');
```


### Related Issues

closes #424