### PR TITLE
Fix ID_Token Support for Non-Standard AWS Cognito OIDC Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 generated-docs/
 npm-debug.log*
 .env
+package-lock.json

--- a/src/base/provider-openid.ts
+++ b/src/base/provider-openid.ts
@@ -73,8 +73,8 @@ export class OpenIDProvider extends OAuth2Provider {
     try {
       super.$validate(options);
 
-      const types = this.storage.get('response-type', '').split(' ');
-      if (Common.includes(types, 'id_token')) {
+      const { id_token, code } = options;
+      if (id_token) {
         const { id_token } = options;
 
         const user = IDToken.parse(id_token);
@@ -94,7 +94,7 @@ export class OpenIDProvider extends OAuth2Provider {
         }
 
         this.storage.set('id-token.raw', id_token);
-      } else if (Common.includes(types, 'code')) {
+      } else if (code) {
         this.storage.delete('id-token.raw');
       }
     } finally {


### PR DESCRIPTION
Since Cognito doesn't use standard OIDC response_type/response semantics we need to parse the id_token whenever it exists in the response rather then only when the original response_type included "id_token".